### PR TITLE
ci: run required checks on all PRs (unblock www/docs PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
     paths-ignore: ['www/**', '*.md']
   pull_request:
+    # No paths-ignore here: required checks (Lint & Type Check, Test) must
+    # report on every PR, otherwise branch protection blocks docs/www-only
+    # PRs forever (the contexts never run → stay pending → unmergeable).
     branches: [main]
-    paths-ignore: ['www/**', '*.md']
 
 jobs:
   lint:


### PR DESCRIPTION
## Description
`Lint & Type Check` and `Test (Python 3.12)` are required by branch protection but were path-ignored on `www/**`/`*.md`. Docs/www-only PRs (incl. dependabot www bumps) never ran them → contexts stayed pending → PRs permanently BLOCKED. This drops `paths-ignore` on the `pull_request` trigger so required contexts always report. Push trigger keeps its paths-ignore.

Root-cause ② of the dependabot deadlock (root-cause ①, the CODEOWNERS review requirement, already removed from branch protection).

## Test Plan
- CI runs on this PR (it touches `.github/workflows/ci.yml`, not path-ignored anyway).
- Going forward, www/docs-only PRs will show Lint & Type Check + Test contexts.