### PR TITLE
fix(release): shrink sdist <1MB + workflow_dispatch for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  # Manual escape hatch: release-please creates Releases as the bot, and
+  # bot-created Releases do NOT trigger workflows. Dispatch this on main to
+  # publish the version currently in pyproject.
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ exclude = [
     "/paper",
     "/scripts",
     "/benchmarks",
+    "/tests",
     "/assets",
     "/.github",
     "/.claude*",


### PR DESCRIPTION
## Description
Fixes 2 of the 3 publish-pipeline blockers (#65):
1. **sdist 3.78MB → 187KB**: `tests/fixtures` (CGNS 3.98MB, STL 3.6MB) were packaged into the sdist, failing publish.yml's `verify sdist < 1MB` guard. Exclude `/tests` from the hatchling sdist target.
2. **workflow_dispatch**: release-please creates Releases as the bot → no workflow trigger → publish.yml never ran. Add `workflow_dispatch` so it can be dispatched manually on `main`.

Remaining (manual): configure **PyPI trusted publisher** for the `pypi` environment (PyPI web UI), then `gh workflow run publish.yml` ships 0.9.0.

## Test Plan
- Built sdist locally in a clean venv: `viznoir-0.9.0.tar.gz` = **187128 bytes** (< 1 MB ✓).
- Wheel unaffected (only packages `src/viznoir`).