### PR TITLE
ci(publish): token auth via PYPI_API_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,3 +60,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Token auth: set repo secret PYPI_API_TOKEN (scoped to the viznoir project).
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Description
Switch publish to API-token auth (option B). Adds `password: ${{ secrets.PYPI_API_TOKEN }}` to gh-action-pypi-publish. Requires repo secret **PYPI_API_TOKEN** (viznoir-scoped). Resolves 'invalid-publisher' without a PyPI trusted-publisher registration.

## Test Plan
- Workflow-only change. After PYPI_API_TOKEN is set, `gh workflow run publish.yml --ref main` publishes the version in pyproject (0.9.0).