### PR TITLE
fix(ci): skip PR Template check for bot authors

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -51,6 +51,15 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            // Bot PRs (dependabot, release-please via github-actions) don't use
+            // the human PR template — pass the check so they aren't permanently
+            // blocked. A skipped job would leave a required check pending; an
+            // early return keeps the check green.
+            const author = context.payload.pull_request.user.login || '';
+            if (author.endsWith('[bot]')) {
+              core.info(`Skipping PR template check for bot author: ${author}`);
+              return;
+            }
             const body = context.payload.pull_request.body || '';
             const errors = [];
 


### PR DESCRIPTION
## Description

The `PR Quality → PR Template` check (`pr-quality.yml`) fails whenever a PR body lacks filled `## Description` / `## Test Plan` sections. Dependabot and release-please PRs use their own body format, so this required check fails on **every** bot PR — currently blocking all 12 open dependabot PRs and the release PRs.

Fix: early-return to a green check when the PR author is a `[bot]`. A `job-level if` skip would leave the required check pending (and still block), so the job runs and passes instead.

## Test Plan

- Human PRs (like this one) still run the full template validation — this PR's own check exercises the non-bot path.
- After merge, dependabot/release-please PRs will report the `PR Template` check as success on their next run (rebase / synchronize).