### PR TITLE
feat(registry): publish to MCP Registry via OIDC

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,31 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*"] # bot-pushed tags do NOT trigger this; use workflow_dispatch
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC auth to the MCP Registry (no secrets needed)
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Sync server.json version from pyproject
+        run: |
+          VERSION=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Authenticate (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > VTK is all you need. Cinema-quality science visualization for AI agents.
 
+<!-- mcp-name: io.github.kimimgo/viznoir -->
+
 [![CI](https://github.com/kimimgo/viznoir/actions/workflows/ci.yml/badge.svg)](https://github.com/kimimgo/viznoir/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/viznoir)](https://pypi.org/project/viznoir/)
 [![Python](https://img.shields.io/pypi/pyversions/viznoir)](https://pypi.org/project/viznoir/)

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "com.github.kimimgo/viznoir",
+  "name": "io.github.kimimgo/viznoir",
   "description": "Cinema-quality science visualization for AI agents. Headless VTK rendering pipeline via MCP — no ParaView GUI, no display server.",
   "title": "viznoir",
   "websiteUrl": "https://kimimgo.github.io/viznoir/",
@@ -8,13 +8,13 @@
     "url": "https://github.com/kimimgo/viznoir",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.9.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "viznoir",
-      "version": "0.7.0",
+      "version": "0.9.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Description
Set up publishing to the official MCP Registry (registry.modelcontextprotocol.io):
- `server.json`: name → `io.github.kimimgo/viznoir` (GitHub-auth namespace requirement), version → 0.9.2
- `README.md`: add `<!-- mcp-name: io.github.kimimgo/viznoir -->` ownership marker (verified against the PyPI package description)
- `.github/workflows/publish-mcp.yml`: OIDC publish (no secrets; `id-token: write` + `mcp-publisher login github-oidc`), syncs server.json version from pyproject at publish time.

Requires PyPI 0.9.2 (with the README marker) to be live first, then dispatch this workflow. GitHub MCP Registry catalog inclusion is a separate email to partnerships@github.com.

## Test Plan
- Workflow/metadata only; CI Lint & Type + Test gate the merge.
- After 0.9.2 is on PyPI, `gh workflow run publish-mcp.yml` registers the server (verify via registry API).