### PR TITLE
fix(registry): shorten server.json description <=100

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.kimimgo/viznoir",
-  "description": "Cinema-quality science visualization for AI agents. Headless VTK rendering pipeline via MCP — no ParaView GUI, no display server.",
+  "description": "Cinema-quality science visualization for AI agents — headless VTK via MCP.",
   "title": "viznoir",
   "websiteUrl": "https://kimimgo.github.io/viznoir/",
   "repository": {


### PR DESCRIPTION
MCP Registry rejected publish with 422 'description expected length <= 100'. Trim server.json description. Registry-metadata only — no new PyPI release needed.