### PR TITLE
ci(dependabot): group updates + register /video

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,30 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      python:
+        patterns: ["*"]
 
   - package-ecosystem: npm
     directory: /www
     schedule:
       interval: monthly
+    groups:
+      www:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /video/viznoir-intro
+    schedule:
+      interval: monthly
+    groups:
+      video:
+        patterns: ["*"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Reduce dependabot PR/notification noise: group all updates per ecosystem/dir into one PR each (python, www, video, actions), and register the previously-unmanaged /video/viznoir-intro npm dir.