### PR TITLE
fix(ci): deploy Node 20->22 for Astro 6.4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: www/package-lock.json
       - run: npm ci


### PR DESCRIPTION
Astro 6.4.2 requires Node 22+; the landing-page deploy was failing with 'Node.js v20 is not supported by Astro'. Bump setup-node to 22.