### PR TITLE
feat(quality): render quality metrics (contrast, edge entropy, field coverage)

### DIFF
--- a/e2e/reports/2026-06-16-60-quality-metrics.md
+++ b/e2e/reports/2026-06-16-60-quality-metrics.md
@@ -1,0 +1,41 @@
+# E2E Evidence — #60 engine/quality.py (render quality metrics)
+
+- **Date**: 2026-06-16
+- **Scenario**: `e2e/scenarios/quality_metrics_e2e.py`
+- **Environment**: oliveeelab host, RTX 4090, VTK offscreen render
+- **Artifact**: `e2e/reports/quality-metrics-render.png` (228 KB, 1920×1080)
+
+## What was driven (real pipeline, not synthetic)
+
+1. Built a VTK wavelet dataset (`vtkRTAnalyticSource`, ParaView "Wavelet" equivalent).
+2. Rendered it through viznoir's **actual** `engine.renderer.render_to_png` → PNG bytes.
+3. Loaded the PNG with `engine.quality.load_png` and ran `measure_quality`.
+4. Compared against a blank (all-white) frame to prove the metric discriminates.
+
+## Results
+
+| frame | contrast | edge_entropy | field_coverage | score |
+|-------|---------:|-------------:|---------------:|------:|
+| **real render** | 0.2125 | 0.0963 | 0.2535 | **0.2272** |
+| blank (255,255,255) | 0.0000 | 0.0000 | 0.0000 | **0.0000** |
+
+The rendered wavelet (RTData scalar field with colorbar over a dark background)
+yields ~25% object coverage and non-zero contrast/edge detail; a blank frame
+scores 0. This is exactly the signal `core/autoexp.py` (#61) needs to keep vs.
+revert a render change.
+
+## Checks (6/6 PASS)
+
+```
+[PASS] score in [0,1]
+[PASS] coverage > 0.05 (object visible)
+[PASS] contrast > 0 (not flat)
+[PASS] edge_entropy > 0 (has detail)
+[PASS] rendered.score > blank.score
+[PASS] blank.score ~ 0
+```
+
+## Unit coverage
+
+`tests/test_engine/test_quality.py` — 20 tests, `quality.py` at 94% line
+coverage. Total suite: 1709 tests (≥1650 guard). ruff + mypy clean.

--- a/e2e/scenarios/quality_metrics_e2e.py
+++ b/e2e/scenarios/quality_metrics_e2e.py
@@ -1,0 +1,67 @@
+"""E2E evidence for #60 — quality metrics on a REAL viznoir render (not synthetic).
+
+Renders a VTK wavelet (vtkRTAnalyticSource) through viznoir's render_to_png on
+the GPU, then runs engine.quality.measure_quality on the resulting PNG and
+checks the metrics are physically sensible (a real render is far richer than a
+blank frame). Writes the PNG next to this report as captured evidence.
+
+Run:  .venv/bin/python e2e/scenarios/quality_metrics_e2e.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import vtk
+
+from viznoir.engine.quality import load_png, measure_quality
+
+OUT = Path(__file__).resolve().parents[1] / "reports"
+OUT.mkdir(parents=True, exist_ok=True)
+PNG = OUT / "quality-metrics-render.png"
+
+
+def main() -> int:
+    # 1) Real dataset: VTK's analytic wavelet (ParaView "Wavelet" equivalent).
+    src = vtk.vtkRTAnalyticSource()
+    src.SetWholeExtent(-10, 10, -10, 10, -10, 10)
+    src.Update()
+    data = src.GetOutput()
+
+    # 2) Render through viznoir's actual pipeline -> PNG bytes -> file.
+    from viznoir.engine.renderer import render_to_png
+
+    png_bytes = render_to_png(data)
+    PNG.write_bytes(png_bytes)
+
+    # 3) Measure quality of the real render.
+    img = load_png(str(PNG))
+    rendered = measure_quality(img)
+
+    # 4) Baseline: a blank frame must score ~0 (the metric discriminates).
+    blank = measure_quality(np.full_like(img, 255), background_color=(255, 255, 255))
+
+    print(f"render PNG:        {PNG}  ({len(png_bytes)} bytes, shape={img.shape})")
+    print(f"rendered metrics:  {rendered.to_dict()}")
+    print(f"blank metrics:     {blank.to_dict()}")
+
+    # 5) Assertions — a real render is informative; a blank frame is not.
+    checks = {
+        "score in [0,1]": 0.0 <= rendered.score <= 1.0,
+        "coverage > 0.05 (object visible)": rendered.field_coverage > 0.05,
+        "contrast > 0 (not flat)": rendered.contrast > 0.0,
+        "edge_entropy > 0 (has detail)": rendered.edge_entropy > 0.0,
+        "rendered.score > blank.score": rendered.score > blank.score,
+        "blank.score ~ 0": blank.score < 0.02,
+    }
+    ok = True
+    for name, passed in checks.items():
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
+        ok = ok and passed
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/viznoir/engine/quality.py
+++ b/src/viznoir/engine/quality.py
@@ -1,0 +1,177 @@
+"""Render quality metrics — contrast, edge entropy, field coverage.
+
+Pure-numpy image-quality measures that judge whether a rendered frame is
+*informative* (vs. blank, clipped, or empty). They feed the autoexp
+modify->render->measure loop (``core/autoexp.py``): a higher score means keep
+the change, a lower score means revert it.
+
+No heavy dependencies — only numpy (always present via VTK). The metric
+functions operate on a rendered image given as a numpy array:
+
+* ``(H, W)``       — grayscale
+* ``(H, W, 3)``    — RGB
+* ``(H, W, 4)``    — RGBA (the alpha channel is ignored)
+
+``load_png()`` converts a PNG file produced by the renderer into such an array.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# Rec. 601 luma weights — perceptual luminance from linear RGB channels.
+_LUMA = np.array([0.299, 0.587, 0.114], dtype=np.float64)
+
+# Score normalisation constants (see ``measure_quality``).
+_RMS_CONTRAST_MAX = 0.5  # std of values in [0, 1] peaks at 0.5 (50/50 black/white)
+_ENTROPY_BINS = 64
+_ENTROPY_MAX = float(np.log2(_ENTROPY_BINS))  # max Shannon entropy for the histogram
+
+
+@dataclass
+class QualityMetrics:
+    """Aggregate render-quality measurement.
+
+    All fields are floats. ``contrast``/``field_coverage`` are in ``[0, 1]``;
+    ``edge_entropy`` is in bits (``>= 0``); ``score`` is a normalised blend in
+    ``[0, 1]`` where higher is a richer, more informative frame.
+    """
+
+    contrast: float
+    edge_entropy: float
+    field_coverage: float
+    score: float
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "contrast": self.contrast,
+            "edge_entropy": self.edge_entropy,
+            "field_coverage": self.field_coverage,
+            "score": self.score,
+        }
+
+
+def _as_rgb(image: np.ndarray) -> np.ndarray:
+    """Coerce an image to a float64 ``(H, W, 3)`` array, dropping any alpha."""
+    arr = np.asarray(image)
+    if arr.ndim == 2:
+        rgb = np.repeat(arr[:, :, None].astype(np.float64), 3, axis=2)
+    elif arr.ndim == 3 and arr.shape[2] in (3, 4):
+        rgb = arr[..., :3].astype(np.float64)
+    else:
+        raise ValueError(f"expected (H,W), (H,W,3) or (H,W,4) image, got shape {arr.shape}")
+    if rgb.size == 0:
+        raise ValueError("image has no pixels")
+    # Float images in [0, 1] are scaled up to the 0-255 range the metrics assume.
+    if arr.dtype.kind == "f" and float(np.nanmax(arr)) <= 1.0:
+        rgb = rgb * 255.0
+    return rgb
+
+
+def _as_luminance(image: np.ndarray) -> np.ndarray:
+    """Coerce an image to a float64 luminance plane in ``[0, 255]``."""
+    return _as_rgb(image) @ _LUMA
+
+
+def contrast(image: np.ndarray) -> float:
+    """RMS contrast in ``[0, 1]`` — the standard deviation of normalised luminance.
+
+    A flat frame is ``0``; a balanced black/white pattern approaches ``0.5``.
+    """
+    luma = _as_luminance(image) / 255.0
+    return float(np.std(luma))
+
+
+def edge_entropy(image: np.ndarray, bins: int = _ENTROPY_BINS) -> float:
+    """Shannon entropy (bits) of the gradient-magnitude histogram.
+
+    Measures how *varied* the edge structure is. A blank frame has a single
+    (zero) gradient bin -> ``0`` bits; a detailed render spreads gradient
+    magnitudes across many bins -> higher entropy.
+    """
+    luma = _as_luminance(image)
+    gy, gx = np.gradient(luma)
+    mag = np.hypot(gx, gy)
+    peak = float(mag.max())
+    if peak <= 1e-9:
+        return 0.0
+    hist, _ = np.histogram(mag, bins=bins, range=(0.0, peak))
+    counts = hist.astype(np.float64)
+    total = counts.sum()
+    if total <= 0:
+        return 0.0
+    probs = counts / total
+    nz = probs[probs > 0]
+    return float(-(nz * np.log2(nz)).sum())
+
+
+def field_coverage(
+    image: np.ndarray,
+    background_color: tuple[float, float, float] | None = None,
+    threshold: float = 12.0,
+) -> float:
+    """Fraction of pixels that differ from the background — i.e. the rendered object.
+
+    Args:
+        image: rendered image array.
+        background_color: RGB of the background. If ``None``, it is inferred as
+            the per-channel median of the four corner pixels.
+        threshold: euclidean RGB distance (0-255) above which a pixel counts as
+            foreground.
+
+    Returns:
+        Coverage fraction in ``[0, 1]``.
+    """
+    rgb = _as_rgb(image)
+    if background_color is None:
+        corners = np.stack([rgb[0, 0], rgb[0, -1], rgb[-1, 0], rgb[-1, -1]])
+        bg = np.median(corners, axis=0)
+    else:
+        bg = np.asarray(background_color, dtype=np.float64)[:3]
+    dist = np.sqrt(((rgb - bg) ** 2).sum(axis=-1))
+    return float((dist > threshold).mean())
+
+
+def measure_quality(
+    image: np.ndarray,
+    background_color: tuple[float, float, float] | None = None,
+) -> QualityMetrics:
+    """Compute all metrics and a normalised ``[0, 1]`` quality score.
+
+    The score weights detail (contrast + edge entropy) over raw coverage, since
+    a richly-detailed frame is more informative than a flatly-filled one:
+    ``0.4 * contrast_norm + 0.4 * entropy_norm + 0.2 * field_coverage``.
+    """
+    c = contrast(image)
+    e = edge_entropy(image)
+    cov = field_coverage(image, background_color=background_color)
+
+    c_norm = min(c / _RMS_CONTRAST_MAX, 1.0)
+    e_norm = min(e / _ENTROPY_MAX, 1.0) if _ENTROPY_MAX > 0 else 0.0
+    score = 0.4 * c_norm + 0.4 * e_norm + 0.2 * cov
+    return QualityMetrics(contrast=c, edge_entropy=e, field_coverage=cov, score=float(score))
+
+
+def load_png(path: str) -> np.ndarray:
+    """Load a PNG file into an ``(H, W, 3)`` uint8 array (lazy VTK import).
+
+    VTK stores images bottom-left-origin, so rows are flipped to match the
+    natural top-left-origin convention the metric helpers expect.
+    """
+    import vtk
+    from vtk.util.numpy_support import vtk_to_numpy
+
+    reader = vtk.vtkPNGReader()
+    reader.SetFileName(str(path))
+    reader.Update()
+    img = reader.GetOutput()
+    w, h, _ = img.GetDimensions()
+    scalars = img.GetPointData().GetScalars()
+    if scalars is None:
+        raise ValueError(f"could not read PNG: {path}")
+    arr = vtk_to_numpy(scalars).reshape(h, w, -1)[::-1]
+    if arr.shape[2] == 1:
+        arr = np.repeat(arr, 3, axis=2)
+    return np.ascontiguousarray(arr[..., :3]).astype(np.uint8)

--- a/tests/test_engine/test_quality.py
+++ b/tests/test_engine/test_quality.py
@@ -1,0 +1,183 @@
+"""Tests for engine/quality.py — render quality metrics.
+
+Pure-numpy image quality measures (contrast, edge entropy, field coverage) that
+feed the autoexp modify->render->measure loop. Synthetic numpy images only, so
+these run in CI without GPU/VTK rendering.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from viznoir.engine.quality import (
+    QualityMetrics,
+    contrast,
+    edge_entropy,
+    field_coverage,
+    measure_quality,
+)
+
+
+# --------------------------------------------------------------------------- #
+# synthetic image helpers
+# --------------------------------------------------------------------------- #
+def _solid(h: int, w: int, color) -> np.ndarray:
+    img = np.empty((h, w, 3), dtype=np.uint8)
+    img[:] = np.asarray(color, dtype=np.uint8)
+    return img
+
+
+def _checkerboard(h: int, w: int, square: int = 8) -> np.ndarray:
+    img = np.zeros((h, w, 3), dtype=np.uint8)
+    yy, xx = np.mgrid[0:h, 0:w]
+    mask = ((yy // square) + (xx // square)) % 2 == 0
+    img[mask] = 255
+    return img
+
+
+def _noise(h: int, w: int, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 256, size=(h, w, 3), dtype=np.uint8)
+
+
+# --------------------------------------------------------------------------- #
+# contrast
+# --------------------------------------------------------------------------- #
+class TestContrast:
+    def test_flat_image_is_zero(self):
+        assert contrast(_solid(32, 32, (128, 128, 128))) == pytest.approx(0.0, abs=1e-6)
+
+    def test_checkerboard_is_high(self):
+        assert contrast(_checkerboard(64, 64)) > 0.4
+
+    def test_in_unit_range(self):
+        assert 0.0 <= contrast(_checkerboard(64, 64)) <= 1.0
+        assert 0.0 <= contrast(_noise(64, 64)) <= 1.0
+
+    def test_ordering_flat_gradient_checker(self):
+        flat = contrast(_solid(32, 32, (120, 120, 120)))
+        ramp = np.stack([np.tile(np.linspace(100, 140, 32, dtype=np.uint8), (32, 1))] * 3, axis=-1)
+        gradient = contrast(ramp)
+        checker = contrast(_checkerboard(32, 32))
+        assert flat < gradient < checker
+
+
+# --------------------------------------------------------------------------- #
+# edge entropy
+# --------------------------------------------------------------------------- #
+class TestEdgeEntropy:
+    def test_flat_image_is_zero(self):
+        assert edge_entropy(_solid(32, 32, (80, 80, 80))) == pytest.approx(0.0, abs=1e-9)
+
+    def test_edges_are_positive(self):
+        assert edge_entropy(_checkerboard(64, 64, square=8)) > 0.0
+
+    def test_noise_richer_than_checkerboard(self):
+        # noise spreads gradient magnitudes across many bins -> higher entropy
+        assert edge_entropy(_noise(64, 64)) > edge_entropy(_checkerboard(64, 64, square=8))
+
+    def test_non_negative(self):
+        assert edge_entropy(_noise(48, 48)) >= 0.0
+
+
+# --------------------------------------------------------------------------- #
+# field coverage
+# --------------------------------------------------------------------------- #
+class TestFieldCoverage:
+    def test_all_background_is_zero(self):
+        bg = (255, 255, 255)
+        assert field_coverage(_solid(32, 32, bg), background_color=bg) == pytest.approx(0.0, abs=1e-6)
+
+    def test_full_object_is_one(self):
+        img = _solid(32, 32, (10, 20, 30))
+        assert field_coverage(img, background_color=(255, 255, 255)) == pytest.approx(1.0, abs=1e-6)
+
+    def test_half_coverage(self):
+        bg = (255, 255, 255)
+        img = _solid(32, 32, bg)
+        img[:16, :] = (10, 10, 10)
+        assert field_coverage(img, background_color=bg) == pytest.approx(0.5, abs=0.02)
+
+    def test_auto_background_from_corners(self):
+        bg = (0, 0, 0)
+        img = _solid(40, 40, bg)
+        img[10:30, 10:30] = (200, 200, 200)
+        assert field_coverage(img) == pytest.approx((20 * 20) / (40 * 40), abs=0.02)
+
+
+# --------------------------------------------------------------------------- #
+# input coercion / validation
+# --------------------------------------------------------------------------- #
+class TestInputHandling:
+    def test_accepts_grayscale(self):
+        gray = np.full((16, 16), 100, dtype=np.uint8)
+        assert contrast(gray) == pytest.approx(0.0, abs=1e-6)
+
+    def test_accepts_rgba(self):
+        rgba = np.zeros((16, 16, 4), dtype=np.uint8)
+        rgba[..., 3] = 255
+        # alpha channel must be ignored
+        assert contrast(rgba) == pytest.approx(0.0, abs=1e-6)
+
+    def test_rejects_bad_shape(self):
+        with pytest.raises(ValueError):
+            contrast(np.zeros((4,), dtype=np.uint8))
+
+
+# --------------------------------------------------------------------------- #
+# measure_quality aggregate
+# --------------------------------------------------------------------------- #
+class TestMeasureQuality:
+    def test_returns_metrics_in_range(self):
+        m = measure_quality(_checkerboard(64, 64))
+        assert isinstance(m, QualityMetrics)
+        assert 0.0 <= m.contrast <= 1.0
+        assert m.edge_entropy >= 0.0
+        assert 0.0 <= m.field_coverage <= 1.0
+        assert 0.0 <= m.score <= 1.0
+
+    def test_blank_scores_lower_than_rich(self):
+        blank = measure_quality(_solid(64, 64, (255, 255, 255)), background_color=(255, 255, 255))
+        rich = measure_quality(_noise(64, 64))
+        assert rich.score > blank.score
+
+    def test_blank_score_is_near_zero(self):
+        blank = measure_quality(_solid(64, 64, (255, 255, 255)), background_color=(255, 255, 255))
+        assert blank.score == pytest.approx(0.0, abs=1e-6)
+
+    def test_to_dict_keys(self):
+        d = measure_quality(_checkerboard(32, 32)).to_dict()
+        assert set(d) >= {"contrast", "edge_entropy", "field_coverage", "score"}
+        assert all(isinstance(v, float) for v in d.values())
+
+
+# --------------------------------------------------------------------------- #
+# load_png round-trip (uses VTK PNG writer/reader — no GPU)
+# --------------------------------------------------------------------------- #
+class TestLoadPng:
+    def test_round_trip(self, tmp_path):
+        from viznoir.engine.quality import load_png
+
+        vtk = pytest.importorskip("vtk")
+        from vtk.util.numpy_support import numpy_to_vtk
+
+        h, w = 6, 4
+        src = _checkerboard(h, w, square=2)
+        # write via VTK (origin bottom-left -> flip rows so the file matches src)
+        img = vtk.vtkImageData()
+        img.SetDimensions(w, h, 1)
+        flat = src[::-1].reshape(-1, 3).astype(np.uint8)
+        scalars = numpy_to_vtk(flat, deep=True)
+        scalars.SetNumberOfComponents(3)
+        img.GetPointData().SetScalars(scalars)
+        path = tmp_path / "tile.png"
+        writer = vtk.vtkPNGWriter()
+        writer.SetFileName(str(path))
+        writer.SetInputData(img)
+        writer.Write()
+
+        out = load_png(str(path))
+        assert out.shape == (h, w, 3)
+        assert out.dtype == np.uint8
+        np.testing.assert_array_equal(out, src)


### PR DESCRIPTION
## Description
Implements `engine/quality.py` (#60) — pure-numpy render-quality metrics that feed the autoexp modify→render→measure loop (#61). First card of the **v0.11.0 Trust & Guard** milestone (anti-hallucination foundation).

- `contrast` — RMS contrast (std of normalized luminance), [0,1]
- `edge_entropy` — Shannon entropy of the gradient-magnitude histogram (detail richness), bits
- `field_coverage` — fraction of non-background pixels (auto-detect bg from corners, or explicit)
- `measure_quality` — normalized [0,1] score blend → `QualityMetrics`
- `load_png` — PNG → ndarray (lazy VTK import)

No new dependencies (numpy only, always present via VTK).

## Test Plan
- `tests/test_engine/test_quality.py` — **20 unit tests** on synthetic images (run in CI without GPU)
- New module at **94% line coverage**; suite now **1709 tests** (>=1650 guard)
- `ruff check` / `ruff format --check` / `mypy` all clean
- **E2E (real GPU render)** — `e2e/scenarios/quality_metrics_e2e.py` renders a VTK wavelet through viznoir's actual `render_to_png`, then measures it. Real render scores **0.2272** (contrast 0.21, edge_entropy 0.096, coverage 0.25) vs a blank frame **0.0** — 6/6 checks pass. Report: `e2e/reports/2026-06-16-60-quality-metrics.md`

Closes #60

🤖 ultraloop iteration 1
