### PR TITLE
feat(tools): validate_render MCP tool — physics guard on render specs

### DIFF
--- a/e2e/reports/2026-06-16-59-validate-render.md
+++ b/e2e/reports/2026-06-16-59-validate-render.md
@@ -1,0 +1,42 @@
+# E2E Evidence — #59 validate_render MCP tool
+
+- **Date**: 2026-06-16
+- **Scenario**: `e2e/scenarios/validate_render_e2e.py`
+- **Driven over**: the real MCP protocol (FastMCP `Client` → in-process viznoir server)
+
+## What was driven (agent-facing path)
+
+1. Wrote a real `.vti` with a signed `pressure` field (range `[-90, 110]`).
+2. Connected a FastMCP `Client` to the viznoir server and listed tools — confirmed
+   `validate_render` is exposed (tool count 23→24).
+3. Called `validate_render` with a **bad** config (sequential `viridis` on signed
+   pressure + out-of-range isovalue) and a **good** config (`coolwarm`,
+   zero-centered range, in-range isovalue).
+
+## Results
+
+```
+field range: [-90.0, 110.0]
+BAD  verdict=fail :: FAIL: pressure_diverging_colormap (warn); empty_isosurface (fail)
+GOOD verdict=pass :: PASS: render choices are physically consistent
+```
+
+## Checks (6/6 PASS)
+
+```
+[PASS] validate_render exposed over MCP
+[PASS] bad config -> FAIL
+[PASS] bad flags pressure colormap (sequential on signed field)
+[PASS] bad flags empty isosurface (out-of-range isovalue)
+[PASS] good config -> PASS
+[PASS] real field range reported
+```
+
+The guard (#58) is now reachable by agents as an MCP tool, validating render
+choices against the dataset's actual physics before they mislead.
+
+## Unit coverage
+
+`tests/test_tools/test_validate_render.py` — 11 tests, `validate_render.py` at
+**100%** line coverage. Tool-count tests updated (compliance 18→19, registration
+inventory). Suite: 1744 tests (≥1650 guard). ruff + mypy (86 files) clean.

--- a/e2e/scenarios/validate_render_e2e.py
+++ b/e2e/scenarios/validate_render_e2e.py
@@ -1,0 +1,109 @@
+"""E2E evidence for #59 — validate_render driven over the real MCP protocol.
+
+Spins up the viznoir FastMCP server in-process, connects a Client, and calls the
+`validate_render` tool exactly as an agent would: once with a bad config
+(sequential colormap on signed pressure + out-of-range isovalue) and once with a
+good config. The bad call must FAIL, the good call must PASS.
+
+Run:  .venv/bin/python e2e/scenarios/validate_render_e2e.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk
+
+
+def _write_vti(path: str) -> None:
+    n = 6
+    npts = n * n * n
+    img = vtk.vtkImageData()
+    img.SetDimensions(n, n, n)
+    pressure = np.linspace(-90.0, 110.0, npts).astype(np.float64)  # signed, crosses zero
+    parr = numpy_to_vtk(pressure, deep=True)
+    parr.SetName("pressure")
+    img.GetPointData().AddArray(parr)
+    writer = vtk.vtkXMLImageDataWriter()
+    writer.SetFileName(path)
+    writer.SetInputData(img)
+    writer.Write()
+
+
+def _verdict(result) -> dict:
+    # FastMCP returns structured content under .data (2.x) or .structured_content.
+    data = getattr(result, "data", None)
+    if data is None:
+        data = getattr(result, "structured_content", None)
+    return data
+
+
+async def main() -> int:
+    from fastmcp import Client
+
+    from viznoir.server import mcp
+
+    tmp = Path(tempfile.mkdtemp()) / "signed.vti"
+    _write_vti(str(tmp))
+
+    async with Client(mcp) as client:
+        names = {t.name for t in await client.list_tools()}
+        assert "validate_render" in names, "validate_render not registered"
+
+        bad = _verdict(
+            await client.call_tool(
+                "validate_render",
+                {
+                    "file_path": str(tmp),
+                    "field_name": "pressure",
+                    "colormap": "viridis",
+                    "scalar_range": [-90.0, 110.0],
+                    "filter_type": "contour",
+                    "isovalue": 9999.0,
+                },
+            )
+        )
+        good = _verdict(
+            await client.call_tool(
+                "validate_render",
+                {
+                    "file_path": str(tmp),
+                    "field_name": "pressure",
+                    "colormap": "coolwarm",
+                    "scalar_range": [-110.0, 110.0],
+                    "filter_type": "contour",
+                    "isovalue": 0.0,
+                },
+            )
+        )
+
+    print(f"field range: [{bad['field']['min']:.1f}, {bad['field']['max']:.1f}]")
+    print(f"BAD  verdict={bad['verdict']} :: {bad['summary']}")
+    print(f"GOOD verdict={good['verdict']} :: {good['summary']}")
+
+    checks = {
+        "validate_render exposed over MCP": "validate_render" in names,
+        "bad config -> FAIL": bad["verdict"] == "fail",
+        "bad flags pressure colormap": any(
+            r["rule"] == "pressure_diverging_colormap" for r in bad["results"]
+        ),
+        "bad flags empty isosurface": any(
+            r["rule"] == "empty_isosurface" and r["status"] == "fail" for r in bad["results"]
+        ),
+        "good config -> PASS": good["verdict"] == "pass",
+        "real field range reported": bad["field"]["min"] < 0 < bad["field"]["max"],
+    }
+    ok = True
+    for name, passed in checks.items():
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
+        ok = ok and passed
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/viznoir/server.py
+++ b/src/viznoir/server.py
@@ -1146,6 +1146,59 @@ async def inspect_physics(
 
 
 # ---------------------------------------------------------------------------
+# validate_render — physics guard on a render spec (pass/warn/fail)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def validate_render(
+    file_path: str,
+    field_name: str,
+    association: Literal["POINTS", "CELLS"] = "POINTS",
+    colormap: str = "Cool to Warm",
+    scalar_range: list[float] | None = None,
+    filter_type: str | None = None,
+    isovalue: float | None = None,
+    camera_position: list[float] | None = None,
+) -> dict[str, Any]:
+    """Physics-check a render spec against the data — pass/warn/fail + fixes.
+
+    Catches hallucinated visualization choices before they mislead: a sequential
+    colormap on signed pressure, a range that hides the zero crossing, an
+    isovalue outside the data range, a temperature below absolute zero, or a
+    camera that doesn't frame the data. Returns a verdict, per-rule results with
+    fix suggestions, and the field's actual range.
+
+    Args:
+        file_path: Path to the VTK/OpenFOAM/CGNS simulation file
+        field_name: Field the render colors by
+        association: POINTS or CELLS
+        colormap: Colormap chosen for the render
+        scalar_range: [min, max] color range (None = full data range)
+        filter_type: Filter applied, e.g. "contour" (enables empty-isosurface check)
+        isovalue: Isovalue for a contour filter (checked against the data range)
+        camera_position: Explicit [x, y, z] camera position (checked vs data bounds)
+    """
+    file_path = _validate_file_path(file_path)
+    logger.debug("tool.validate_render: start file=%s field=%s", file_path, field_name)
+    t0 = time.monotonic()
+    from viznoir.tools.validate_render import validate_render_impl
+
+    result = await validate_render_impl(
+        file_path,
+        field_name,
+        association=association,
+        colormap=colormap,
+        scalar_range=scalar_range,
+        filter_type=filter_type,
+        isovalue=isovalue,
+        camera_position=camera_position,
+    )
+    logger.debug("tool.validate_render: done in %.2fs", time.monotonic() - t0)
+    return result
+
+
+# ---------------------------------------------------------------------------
 # analyze_data — VTK data insight extraction [DEPRECATED: use inspect_physics]
 # ---------------------------------------------------------------------------
 

--- a/src/viznoir/tools/validate_render.py
+++ b/src/viznoir/tools/validate_render.py
@@ -1,0 +1,127 @@
+"""validate_render tool — physics-check a render spec before (or after) rendering.
+
+Runs the guard validator (``viznoir.guard``) against a render's choices
+(colormap, scalar range, camera, isosurface) given the *actual* field
+statistics of the dataset, returning pass/warn/fail verdicts plus fix
+suggestions. This is the anti-hallucination gate exposed over MCP (#59).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal
+
+import numpy as np
+from vtk.util.numpy_support import vtk_to_numpy
+
+from viznoir.engine.readers import read_dataset
+from viznoir.errors import FieldNotFoundError
+from viznoir.guard import GuardContext, validate
+
+_ISO_FILTERS = {"contour", "isosurface", "iso"}
+
+
+def _field_stats(dataset: Any, field_name: str) -> tuple[float, float, bool, str]:
+    """Return (min, max, is_magnitude, association) for ``field_name``.
+
+    Vector fields are reduced to their magnitude. Raises FieldNotFoundError if
+    the field is absent from both point and cell data.
+    """
+    arr = dataset.GetPointData().GetArray(field_name)
+    association = "POINTS"
+    if arr is None:
+        arr = dataset.GetCellData().GetArray(field_name)
+        association = "CELLS"
+    if arr is None:
+        raise FieldNotFoundError(f"field '{field_name}' not found in point or cell data")
+
+    data = vtk_to_numpy(arr)
+    is_magnitude = arr.GetNumberOfComponents() > 1
+    scalar = np.linalg.norm(data, axis=1) if is_magnitude else data
+    return float(np.min(scalar)), float(np.max(scalar)), is_magnitude, association
+
+
+def build_guard_context(
+    dataset: Any,
+    field_name: str,
+    *,
+    colormap: str | None = None,
+    scalar_range: list[float] | None = None,
+    filter_type: str | None = None,
+    isovalue: float | None = None,
+    camera_position: list[float] | None = None,
+) -> GuardContext:
+    """Assemble a GuardContext from a dataset's field statistics + render choices.
+
+    For isosurface filters the cell count is estimated statically: an isovalue
+    outside the data range yields an empty surface (the most common mistake).
+    """
+    fmin, fmax, is_magnitude, _assoc = _field_stats(dataset, field_name)
+
+    iso_count: int | None = None
+    if filter_type is not None and filter_type.lower() in _ISO_FILTERS and isovalue is not None:
+        # outside the data range -> the contour is empty; inside -> non-empty.
+        iso_count = 0 if (isovalue < fmin or isovalue > fmax) else 1
+
+    return GuardContext(
+        field_name=field_name,
+        field_min=fmin,
+        field_max=fmax,
+        is_magnitude=is_magnitude,
+        colormap=colormap,
+        scalar_range=(scalar_range[0], scalar_range[1]) if scalar_range else None,
+        camera_position=tuple(camera_position) if camera_position else None,  # type: ignore[arg-type]
+        data_bounds=tuple(dataset.GetBounds()),  # type: ignore[arg-type]
+        filter_type=filter_type,
+        isosurface_cell_count=iso_count,
+    )
+
+
+async def validate_render_impl(
+    file_path: str,
+    field_name: str,
+    *,
+    association: Literal["POINTS", "CELLS"] = "POINTS",
+    colormap: str = "Cool to Warm",
+    scalar_range: list[float] | None = None,
+    filter_type: str | None = None,
+    isovalue: float | None = None,
+    camera_position: list[float] | None = None,
+) -> dict[str, Any]:
+    """Validate a render spec against the dataset's physics. Returns a verdict report."""
+
+    def _run() -> dict[str, Any]:
+        dataset = read_dataset(file_path)
+        fmin, fmax, is_magnitude, assoc = _field_stats(dataset, field_name)
+        ctx = build_guard_context(
+            dataset,
+            field_name,
+            colormap=colormap,
+            scalar_range=scalar_range,
+            filter_type=filter_type,
+            isovalue=isovalue,
+            camera_position=camera_position,
+        )
+        report = validate(ctx)
+        warnings = [r for r in report.results if r.status.value in ("warn", "fail")]
+        return {
+            "verdict": report.verdict.value,
+            "results": [r.to_dict() for r in report.results],
+            "field": {
+                "name": field_name,
+                "min": fmin,
+                "max": fmax,
+                "is_magnitude": is_magnitude,
+                "association": assoc,
+            },
+            "summary": (
+                f"{report.verdict.value.upper()}: "
+                + (
+                    "; ".join(f"{w.rule} ({w.status.value})" for w in warnings)
+                    if warnings
+                    else "render choices are physically consistent"
+                )
+            ),
+        }
+
+    return await asyncio.get_event_loop().run_in_executor(None, _run)

--- a/tests/test_tools/test_mcp_compliance.py
+++ b/tests/test_tools/test_mcp_compliance.py
@@ -39,6 +39,7 @@ def _get_tool_functions() -> dict:
         "probe_timeseries",
         "batch_render",
         "preview_3d",
+        "validate_render",
     ]
     tools = {}
     for name in names:
@@ -83,7 +84,7 @@ class TestToolCompliance:
 
     def test_tool_count_matches_expected(self):
         """Guard against accidentally dropping or adding tools."""
-        assert len(_get_tool_functions()) == 18
+        assert len(_get_tool_functions()) == 19
 
     def test_docstrings_are_unique(self):
         """No two tools should have the same first-line docstring."""

--- a/tests/test_tools/test_server_registration.py
+++ b/tests/test_tools/test_server_registration.py
@@ -36,6 +36,7 @@ class TestServerRegistration:
             "batch_render",
             "preview_3d",
             "compose_assets",
+            "validate_render",
         ]
         for name in tool_funcs:
             assert hasattr(server, name), f"Missing tool function: {name}"

--- a/tests/test_tools/test_validate_render.py
+++ b/tests/test_tools/test_validate_render.py
@@ -1,0 +1,124 @@
+"""Tests for the validate_render tool — physics guard on a render spec.
+
+Uses small in-memory VTK datasets written to temp .vti files (no GPU render),
+so these run in CI.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk
+
+from viznoir.engine.readers import read_dataset
+from viznoir.errors import FieldNotFoundError
+from viznoir.tools.validate_render import (
+    _field_stats,
+    build_guard_context,
+    validate_render_impl,
+)
+
+
+def _make_vti(tmp_path) -> str:
+    """A 5^3 ImageData with a signed 'pressure' scalar and a 'velocity' vector (|v|=5)."""
+    n = 5
+    npts = n * n * n
+    img = vtk.vtkImageData()
+    img.SetDimensions(n, n, n)
+
+    pressure = np.linspace(-50.0, 80.0, npts).astype(np.float64)
+    parr = numpy_to_vtk(pressure, deep=True)
+    parr.SetName("pressure")
+    img.GetPointData().AddArray(parr)
+
+    velocity = np.tile(np.array([3.0, 4.0, 0.0]), (npts, 1)).astype(np.float64)  # |v| = 5
+    varr = numpy_to_vtk(velocity, deep=True)
+    varr.SetNumberOfComponents(3)
+    varr.SetName("velocity")
+    img.GetPointData().AddArray(varr)
+
+    path = tmp_path / "data.vti"
+    writer = vtk.vtkXMLImageDataWriter()
+    writer.SetFileName(str(path))
+    writer.SetInputData(img)
+    writer.Write()
+    return str(path)
+
+
+class TestFieldStats:
+    def test_signed_scalar(self, tmp_path):
+        ds = read_dataset(_make_vti(tmp_path))
+        fmin, fmax, is_mag, assoc = _field_stats(ds, "pressure")
+        assert fmin == pytest.approx(-50.0)
+        assert fmax == pytest.approx(80.0)
+        assert is_mag is False
+        assert assoc == "POINTS"
+
+    def test_vector_reduced_to_magnitude(self, tmp_path):
+        ds = read_dataset(_make_vti(tmp_path))
+        fmin, fmax, is_mag, _ = _field_stats(ds, "velocity")
+        assert is_mag is True
+        assert fmin == pytest.approx(5.0)
+        assert fmax == pytest.approx(5.0)
+
+    def test_missing_field_raises(self, tmp_path):
+        ds = read_dataset(_make_vti(tmp_path))
+        with pytest.raises(FieldNotFoundError):
+            _field_stats(ds, "does_not_exist")
+
+
+class TestBuildGuardContext:
+    def test_carries_field_stats_and_bounds(self, tmp_path):
+        ds = read_dataset(_make_vti(tmp_path))
+        ctx = build_guard_context(ds, "pressure", colormap="viridis")
+        assert ctx.field_min < 0.0 < ctx.field_max
+        assert ctx.data_bounds is not None and len(ctx.data_bounds) == 6
+
+    def test_isovalue_out_of_range_is_empty(self, tmp_path):
+        ds = read_dataset(_make_vti(tmp_path))
+        ctx = build_guard_context(ds, "pressure", filter_type="contour", isovalue=1000.0)
+        assert ctx.isosurface_cell_count == 0
+
+    def test_isovalue_in_range_is_nonempty(self, tmp_path):
+        ds = read_dataset(_make_vti(tmp_path))
+        ctx = build_guard_context(ds, "pressure", filter_type="contour", isovalue=0.0)
+        assert ctx.isosurface_cell_count == 1
+
+    def test_no_filter_leaves_iso_none(self, tmp_path):
+        ds = read_dataset(_make_vti(tmp_path))
+        ctx = build_guard_context(ds, "pressure")
+        assert ctx.isosurface_cell_count is None
+
+
+class TestValidateRenderImpl:
+    async def test_bad_pressure_colormap_warns(self, tmp_path):
+        res = await validate_render_impl(
+            _make_vti(tmp_path), "pressure", colormap="viridis", scalar_range=[-50.0, 80.0]
+        )
+        assert res["verdict"] in ("warn", "fail")
+        assert res["field"]["min"] == pytest.approx(-50.0)
+        assert res["field"]["is_magnitude"] is False
+        assert any(r["rule"] == "pressure_diverging_colormap" for r in res["results"])
+
+    async def test_good_magnitude_config_passes(self, tmp_path):
+        res = await validate_render_impl(_make_vti(tmp_path), "velocity", colormap="viridis", scalar_range=[0.0, 5.0])
+        assert res["verdict"] == "pass"
+        assert res["field"]["is_magnitude"] is True
+
+    async def test_empty_isosurface_fails(self, tmp_path):
+        res = await validate_render_impl(
+            _make_vti(tmp_path),
+            "pressure",
+            colormap="coolwarm",
+            scalar_range=[-80.0, 80.0],
+            filter_type="contour",
+            isovalue=9999.0,
+        )
+        assert res["verdict"] == "fail"
+        assert "summary" in res and res["summary"].startswith("FAIL")
+
+    async def test_result_shape(self, tmp_path):
+        res = await validate_render_impl(_make_vti(tmp_path), "pressure", colormap="coolwarm")
+        assert {"verdict", "results", "field", "summary"} <= set(res)
+        assert {"name", "min", "max", "is_magnitude", "association"} <= set(res["field"])


### PR DESCRIPTION
## Description
`validate_render` (#59) — the **24th MCP tool**, exposing the physics guard (#58) to agents. Runs the guard validator against a render's *choices* given the dataset's **real** field statistics, returning pass/warn/fail + fix suggestions. Third card of **v0.11.0 Trust & Guard**.

- loads the file, extracts the field's true min/max (vectors → magnitude) + data bounds
- estimates empty isosurfaces statically (isovalue vs data range) — no render needed
- returns `{verdict, results[], field{min,max,is_magnitude,...}, summary}` over MCP

`tools/validate_render.py` (`build_guard_context` + `validate_render_impl`) + `server.py` registration.

## Test Plan
- `tests/test_tools/test_validate_render.py` — **11 tests** on in-memory VTK datasets (CI, no GPU); `validate_render.py` at **100%** coverage
- Tool-count tests updated 23→24 (`test_mcp_compliance` 18→19, registration inventory); all 39 count/registration tests green
- Suite **1744 tests** (≥1650 guard); `ruff` + `mypy` (86 files) clean
- **E2E over the real MCP protocol** — `e2e/scenarios/validate_render_e2e.py`: FastMCP `Client` → viznoir server → `validate_render`. On a signed field `[-90, 110]`, a **bad** config (sequential colormap + out-of-range isovalue) → **FAIL**, a **good** config → **PASS**. 6/6 checks pass. Report: `e2e/reports/2026-06-16-59-validate-render.md`

Closes #59

🤖 ultraloop iteration 3
