### PR TITLE
feat(autoexp): modify->render->measure->keep/revert ratchet (pilot)

### DIFF
--- a/e2e/reports/2026-06-16-61-autoexp.md
+++ b/e2e/reports/2026-06-16-61-autoexp.md
@@ -1,0 +1,48 @@
+# E2E Evidence — #61 core/autoexp.py (modify→render→measure→keep/revert)
+
+- **Date**: 2026-06-16
+- **Scenario**: `e2e/scenarios/autoexp_e2e.py`
+- **Environment**: oliveeelab host, RTX 4090, real VTK renders
+
+## What was driven (real renders, real quality scoring)
+
+1. Rendered a VTK wavelet (`RTData`, range `[37.4, 276.8]`) through viznoir's
+   real `render_to_png` once per **physics-appropriate** colormap candidate
+   (`engine.presets.candidates_for` → sequential maps for this one-sided field).
+2. Measured each render with `engine.quality.measure_quality` (#60).
+3. Let the autoexp ratchet KEEP only improvements (else REVERT).
+
+## Results
+
+```
+field RTData range [37.4, 276.8] -> candidates: ['viridis', 'plasma', 'inferno', 'turbo']
+baseline (grayscale) score: 0.1212
+  KEEP baseline             score=0.1212
+  skip colormap=viridis     score=0.1103
+  skip colormap=plasma      score=0.1151
+  skip colormap=inferno     score=0.1068
+  KEEP colormap=turbo       score=0.2196
+best: turbo  score=0.2196  improved=True
+```
+
+autoexp rendered the baseline + 4 candidates, measured each, and the ratchet
+kept only `turbo` (the one that beat the running best). Lower-scoring candidates
+were reverted — the ratchet never moves backward.
+
+## Checks (4/4 PASS)
+
+```
+[PASS] ran baseline + all candidates (5 renders)
+[PASS] best_score >= baseline
+[PASS] best is a real colormap
+[PASS] every trial measured a valid [0,1] score
+```
+
+This is the active counterpart to the guard: the guard (#58/#59) *constrains*
+choices to physics-appropriate ones; autoexp *optimizes* quality within them.
+
+## Unit coverage
+
+`tests/test_core/test_autoexp.py` (8) + `tests/test_engine/test_presets.py` (8)
+— 16 tests, both modules at **100%** coverage (fake render_fn, no GPU). Suite:
+1760 tests (≥1650 guard). ruff + mypy (88 files) clean.

--- a/e2e/scenarios/autoexp_e2e.py
+++ b/e2e/scenarios/autoexp_e2e.py
@@ -1,0 +1,66 @@
+"""E2E evidence for #61 — autoexp picks the best colormap via real GPU renders.
+
+Renders a VTK wavelet through viznoir's real renderer with each physics-
+appropriate colormap candidate (engine.presets), measures each with the quality
+metric (engine.quality), and lets the autoexp ratchet keep the best. Proves the
+modify->render->measure->keep/revert loop works end-to-end on actual renders.
+
+Run:  .venv/bin/python e2e/scenarios/autoexp_e2e.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import vtk
+
+from viznoir.core.autoexp import autoexp
+from viznoir.engine.presets import candidates_for
+from viznoir.engine.quality import load_png
+from viznoir.engine.renderer import RenderConfig, render_to_png
+
+_TMP = Path(tempfile.mkdtemp())
+
+
+def main() -> int:
+    src = vtk.vtkRTAnalyticSource()
+    src.SetWholeExtent(-10, 10, -10, 10, -10, 10)
+    src.Update()
+    data = src.GetOutput()
+    rng = data.GetPointData().GetArray("RTData").GetRange()
+    fmin, fmax = float(rng[0]), float(rng[1])
+
+    def render_fn(params: dict):
+        cfg = RenderConfig(colormap=params["colormap"], array_name="RTData")
+        png = _TMP / f"{params['colormap'].replace(' ', '_')}.png"
+        png.write_bytes(render_to_png(data, cfg))
+        return load_png(str(png))
+
+    # RTData is one-sided positive -> sequential colormap candidates.
+    candidates = [c.as_params() for c in candidates_for(fmin, fmax)]
+    print(f"field RTData range [{fmin:.1f}, {fmax:.1f}] -> candidates: {[c['colormap'] for c in candidates]}")
+
+    result = autoexp({"colormap": "grayscale"}, candidates, render_fn)
+
+    print(f"baseline (grayscale) score: {result.baseline_score:.4f}")
+    for t in result.trials:
+        print(f"  {'KEEP' if t.kept else 'skip'} {t.label:20s} score={t.score:.4f}")
+    print(f"best: {result.best_params['colormap']} score={result.best_score:.4f} improved={result.improved}")
+
+    checks = {
+        "ran baseline + all candidates": len(result.trials) == 1 + len(candidates),
+        "best_score >= baseline": result.best_score >= result.baseline_score,
+        "best is a real colormap": isinstance(result.best_params.get("colormap"), str),
+        "every trial measured a score": all(0.0 <= t.score <= 1.0 for t in result.trials),
+    }
+    ok = True
+    for name, passed in checks.items():
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
+        ok = ok and passed
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/viznoir/core/autoexp.py
+++ b/src/viznoir/core/autoexp.py
@@ -1,0 +1,108 @@
+"""autoexp — modify -> render -> measure -> keep/revert loop (Git Ratcheting pilot).
+
+Greedy hill-climb over render parameters using ``engine.quality.measure_quality``
+as the objective: try each candidate, render it, measure quality, and KEEP it
+only if the score improves (the ratchet never moves backward), else REVERT. The
+render step is injected (``render_fn``) so the loop is testable without a GPU;
+``engine.presets.candidates_for`` supplies physics-appropriate candidates,
+combining the quality metric (#60) with the guard's physics knowledge (#58).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from viznoir.engine.quality import QualityMetrics, measure_quality
+
+RenderFn = Callable[[dict[str, Any]], np.ndarray]
+
+
+@dataclass
+class Trial:
+    """One modify->render->measure step and whether the ratchet kept it."""
+
+    params: dict[str, Any]
+    score: float
+    metrics: QualityMetrics
+    kept: bool
+    label: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "params": self.params,
+            "score": self.score,
+            "metrics": self.metrics.to_dict(),
+            "kept": self.kept,
+            "label": self.label,
+        }
+
+
+@dataclass
+class AutoexpResult:
+    """Outcome of an autoexp run: the best params found plus the full trial log."""
+
+    best_params: dict[str, Any]
+    best_score: float
+    baseline_score: float
+    improved: bool
+    trials: list[Trial]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "best_params": self.best_params,
+            "best_score": self.best_score,
+            "baseline_score": self.baseline_score,
+            "improved": self.improved,
+            "trials": [t.to_dict() for t in self.trials],
+        }
+
+
+def _label(cand: dict[str, Any]) -> str:
+    return ", ".join(f"{k}={v}" for k, v in cand.items()) or "noop"
+
+
+def autoexp(
+    base_params: dict[str, Any],
+    candidates: list[dict[str, Any]],
+    render_fn: RenderFn,
+    *,
+    background_color: tuple[float, float, float] | None = None,
+    min_delta: float = 0.0,
+) -> AutoexpResult:
+    """Greedily try ``candidates`` on top of ``base_params``, keeping improvements.
+
+    Args:
+        base_params: starting render parameters.
+        candidates: parameter overrides to try (each applied on the current best).
+        render_fn: maps a params dict to a rendered image (numpy array).
+        background_color: passed to the quality metric for coverage detection.
+        min_delta: a candidate must beat the current score by more than this to be
+            kept (guards against churn on noise).
+
+    Returns:
+        AutoexpResult with the best params, baseline/best scores, and the trial log.
+    """
+    current = dict(base_params)
+    current_metrics = measure_quality(render_fn(current), background_color=background_color)
+    baseline = current_metrics.score
+    trials = [Trial(dict(current), baseline, current_metrics, True, "baseline")]
+
+    for cand in candidates:
+        trial_params = {**current, **cand}
+        metrics = measure_quality(render_fn(trial_params), background_color=background_color)
+        keep = metrics.score > current_metrics.score + min_delta
+        trials.append(Trial(trial_params, metrics.score, metrics, keep, _label(cand)))
+        if keep:
+            current, current_metrics = trial_params, metrics
+
+    return AutoexpResult(
+        best_params=current,
+        best_score=current_metrics.score,
+        baseline_score=baseline,
+        improved=current_metrics.score > baseline + min_delta,
+        trials=trials,
+    )

--- a/src/viznoir/engine/presets.py
+++ b/src/viznoir/engine/presets.py
@@ -1,0 +1,48 @@
+"""Domain render-tuning presets for autoexp — physics-appropriate render candidates.
+
+Distinct from ``presets/registry.py`` (case-level scene presets): these are
+field-level render-parameter candidates (colormaps tuned to the field's physics)
+that the autoexp loop tries and scores. Encodes the same physics the guard checks
+(#58): signed fields get diverging colormaps, magnitudes get sequential ones.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Physics-appropriate colormap families (names per engine.colormaps COLORMAP_REGISTRY).
+DIVERGING_COLORMAPS = ["coolwarm", "rdylgn"]
+SEQUENTIAL_COLORMAPS = ["viridis", "plasma", "inferno", "turbo"]
+
+
+@dataclass(frozen=True)
+class RenderPreset:
+    """A candidate render tweak the autoexp loop can try."""
+
+    name: str
+    colormap: str
+    description: str
+
+    def as_params(self) -> dict[str, str]:
+        """Render-parameter override this preset applies."""
+        return {"colormap": self.colormap}
+
+
+def is_signed_field(field_min: float | None, field_max: float | None, is_magnitude: bool = False) -> bool:
+    """True when a scalar field crosses zero (and is not a magnitude)."""
+    if is_magnitude or field_min is None or field_max is None:
+        return False
+    return field_min < 0.0 < field_max
+
+
+def candidates_for(field_min: float | None, field_max: float | None, is_magnitude: bool = False) -> list[RenderPreset]:
+    """Physics-appropriate render presets to try for a field's statistics.
+
+    Signed fields (crossing zero) get diverging colormaps; magnitudes and
+    one-sided fields get sequential colormaps.
+    """
+    if is_signed_field(field_min, field_max, is_magnitude):
+        family, kind = DIVERGING_COLORMAPS, "diverging"
+    else:
+        family, kind = SEQUENTIAL_COLORMAPS, "sequential"
+    return [RenderPreset(name=c, colormap=c, description=f"{kind} {c}") for c in family]

--- a/tests/test_core/test_autoexp.py
+++ b/tests/test_core/test_autoexp.py
@@ -1,0 +1,76 @@
+"""Tests for core/autoexp.py — the modify->render->measure->keep/revert ratchet.
+
+A fake render_fn maps params to synthetic images of known quality, so the loop
+logic is exercised without a GPU.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from viznoir.core.autoexp import AutoexpResult, Trial, autoexp
+
+
+def _flat() -> np.ndarray:
+    return np.full((32, 32, 3), 128, dtype=np.uint8)
+
+
+def _rich(seed: int = 0) -> np.ndarray:
+    return np.random.default_rng(seed).integers(0, 256, size=(32, 32, 3), dtype=np.uint8)
+
+
+def _render(params: dict) -> np.ndarray:
+    """colormap 'rich' -> high-quality image, anything else -> flat (score ~0)."""
+    return _rich() if params.get("colormap") == "rich" else _flat()
+
+
+class TestAutoexp:
+    def test_keeps_improvement(self):
+        result = autoexp({"colormap": "flat"}, [{"colormap": "rich"}], _render)
+        assert isinstance(result, AutoexpResult)
+        assert result.improved is True
+        assert result.best_params["colormap"] == "rich"
+        assert result.best_score > result.baseline_score
+
+    def test_reverts_regression(self):
+        # baseline already good; a flat candidate must NOT be kept
+        result = autoexp({"colormap": "rich"}, [{"colormap": "flat"}], _render)
+        assert result.improved is False
+        assert result.best_params["colormap"] == "rich"
+        assert result.trials[-1].kept is False
+
+    def test_picks_best_of_several(self):
+        result = autoexp(
+            {"colormap": "flat"},
+            [{"colormap": "flat2"}, {"colormap": "rich"}, {"colormap": "flat3"}],
+            _render,
+        )
+        assert result.best_params["colormap"] == "rich"
+
+    def test_min_delta_blocks_marginal(self):
+        # huge min_delta means even a real improvement is rejected
+        result = autoexp({"colormap": "flat"}, [{"colormap": "rich"}], _render, min_delta=1.0)
+        assert result.improved is False
+        assert result.best_params["colormap"] == "flat"
+
+    def test_empty_candidates_is_baseline(self):
+        result = autoexp({"colormap": "rich"}, [], _render)
+        assert result.improved is False
+        assert len(result.trials) == 1
+        assert result.trials[0].label == "baseline"
+
+    def test_baseline_recorded_and_kept(self):
+        result = autoexp({"colormap": "flat"}, [{"colormap": "rich"}], _render)
+        assert result.trials[0].label == "baseline"
+        assert result.trials[0].kept is True
+
+    def test_to_dict(self):
+        result = autoexp({"colormap": "flat"}, [{"colormap": "rich"}], _render)
+        d = result.to_dict()
+        assert {"best_params", "best_score", "baseline_score", "improved", "trials"} <= set(d)
+        assert isinstance(d["trials"], list)
+        assert {"params", "score", "metrics", "kept", "label"} <= set(d["trials"][0])
+
+    def test_trial_dataclass(self):
+        result = autoexp({"colormap": "rich"}, [], _render)
+        assert isinstance(result.trials[0], Trial)

--- a/tests/test_engine/test_presets.py
+++ b/tests/test_engine/test_presets.py
@@ -1,0 +1,44 @@
+"""Tests for engine/presets.py — physics-appropriate render candidates for autoexp."""
+
+from __future__ import annotations
+
+from viznoir.engine.presets import (
+    DIVERGING_COLORMAPS,
+    SEQUENTIAL_COLORMAPS,
+    RenderPreset,
+    candidates_for,
+    is_signed_field,
+)
+
+
+class TestIsSignedField:
+    def test_crosses_zero(self):
+        assert is_signed_field(-5.0, 5.0) is True
+
+    def test_one_sided_positive(self):
+        assert is_signed_field(2.0, 9.0) is False
+
+    def test_magnitude_never_signed(self):
+        assert is_signed_field(-5.0, 5.0, is_magnitude=True) is False
+
+    def test_missing_stats(self):
+        assert is_signed_field(None, 5.0) is False
+
+
+class TestCandidatesFor:
+    def test_signed_field_gets_diverging(self):
+        cands = candidates_for(-50.0, 80.0)
+        assert [c.colormap for c in cands] == DIVERGING_COLORMAPS
+
+    def test_magnitude_gets_sequential(self):
+        cands = candidates_for(0.0, 5.0, is_magnitude=True)
+        assert [c.colormap for c in cands] == SEQUENTIAL_COLORMAPS
+
+    def test_one_sided_gets_sequential(self):
+        cands = candidates_for(10.0, 90.0)
+        assert [c.colormap for c in cands] == SEQUENTIAL_COLORMAPS
+
+    def test_returns_render_presets(self):
+        cands = candidates_for(-1.0, 1.0)
+        assert all(isinstance(c, RenderPreset) for c in cands)
+        assert cands[0].as_params() == {"colormap": cands[0].colormap}


### PR DESCRIPTION
## Description
`core/autoexp.py` (#61) — the **modify→render→measure→keep/revert** pilot ("Git Ratcheting"). A greedy hill-climb over render parameters using the quality metric (#60) as the objective: try each candidate, render it, measure quality, and KEEP it only if the score improves, else REVERT. Fourth card of **v0.11.0 Trust & Guard** — the *active* counterpart to the guard.

- `core/autoexp.py`: `autoexp(base_params, candidates, render_fn, ...)` → `AutoexpResult` (best params + full trial log). `render_fn` is injected → GPU-free testable.
- `engine/presets.py`: `candidates_for(field_min, field_max, is_magnitude)` → physics-appropriate render candidates (signed → diverging, magnitude → sequential), mirroring the guard (#58). Distinct from `presets/registry.py` (case scenes), so no duplication.

The guard **constrains** choices to physics-appropriate ones; autoexp **optimizes** quality within them.

## Test Plan
- `tests/test_core/test_autoexp.py` (8) + `tests/test_engine/test_presets.py` (8) — **16 tests**, both modules **100%** coverage (fake `render_fn`, no GPU)
- Suite **1760 tests** (≥1650 guard); `ruff` + `mypy` (88 files) clean
- **E2E (real GPU renders)** — `e2e/scenarios/autoexp_e2e.py`: rendered the wavelet with 4 colormap candidates, measured each, and the ratchet kept **turbo (0.22)** over baseline **grayscale (0.12)**, reverting viridis/plasma/inferno. 4/4 checks pass. Report: `e2e/reports/2026-06-16-61-autoexp.md`

Closes #61

🤖 ultraloop iteration 4
