### PR TITLE
ci: run test/lint on self-hosted GPU runner (RTX 4090)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   lint:
     name: Lint & Type Check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
 
@@ -36,7 +36,7 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: lint
     strategy:
       fail-fast: false
@@ -56,7 +56,11 @@ jobs:
 
       - name: Test (pytest)
         env:
-          VTK_DEFAULT_OPENGL_WINDOW: vtkOSOpenGLRenderWindow
+          # Self-hosted oliveeelab runner has an RTX 4090 — use EGL (OSMesa
+          # segfaults here) and run the GPU rendering tests on 3.12 (the
+          # coverage-gate version), which lifts coverage from ~86% to ~95%.
+          VTK_DEFAULT_OPENGL_WINDOW: vtkEGLRenderWindow
+          VIZNOIR_RUN_GPU_TESTS: ${{ matrix.python-version == '3.12' && '1' || '' }}
         run: pytest --cov=viznoir --cov-report=term-missing --cov-report=xml -q
 
       - name: Coverage threshold check

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,9 @@ from viznoir.core.compiler import ScriptCompiler
 # ---------------------------------------------------------------------------
 
 _IS_CI = bool(os.environ.get("CI"))
+# Opt-in to run the GPU rendering tests even under CI — set on a self-hosted
+# runner that actually has a GPU/EGL (e.g. the oliveeelab RTX 4090 runner).
+_RUN_GPU = bool(os.environ.get("VIZNOIR_RUN_GPU_TESTS"))
 
 # Test files/classes that require VTK GPU rendering (segfault in CI).
 # All *_vtk.py files are also auto-skipped via endswith("_vtk.py") pattern below.
@@ -31,8 +34,11 @@ _RENDERING_TEST_CLASSES = {
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Auto-skip VTK rendering tests in CI (no GPU/EGL/OSMesa)."""
-    if not _IS_CI:
+    """Auto-skip VTK rendering tests in CI (no GPU/EGL/OSMesa).
+
+    A self-hosted runner with a real GPU sets VIZNOIR_RUN_GPU_TESTS=1 to run them.
+    """
+    if not _IS_CI or _RUN_GPU:
         return
 
     skip_render = pytest.mark.skip(reason="VTK rendering requires GPU (not available in CI)")


### PR DESCRIPTION
## Description
Converts the CI **lint + test** jobs to the self-hosted `oliveeelab` runner (RTX 4090) and runs the **GPU rendering tests** on Python 3.12 — the version that gates coverage (#97, user decision: self-hosted CI).

- `ci.yml`: `runs-on: ubuntu-latest` → `self-hosted` for lint + test
- test (3.12): `VIZNOIR_RUN_GPU_TESTS=1` + `VTK_DEFAULT_OPENGL_WINDOW=vtkEGLRenderWindow` (verified: **OSMesa segfaults** on this host, **EGL passes**)
- `conftest.py`: new `VIZNOIR_RUN_GPU_TESTS` opt-in so the GPU tests run only where a GPU exists (local or this runner), still auto-skipped on GitHub-hosted

**publish / deploy / security / scorecard stay on GitHub-hosted** — public-repo safety (fork PRs shouldn't run on the homelab) and PyPI trusted publishing is configured for GitHub's OIDC.

This lifts measured coverage **~86% → ~95%** by covering the rendering code GitHub-hosted CI must skip (`engine/export.py` 9→100%, `engine/filters.py` 27→99%), unblocking the 90% gate (#62).

## Test Plan
- Verified locally: `CI=1 VIZNOIR_RUN_GPU_TESTS=1` runs the GPU tests (140 pass, EGL); `CI=1` alone skips them (unchanged hosted behavior)
- Verified backend: EGL passes, OSMesa segfaults → EGL is required
- Full suite with GPU tests: **1747 passed, 13 skipped, 95% coverage**
- **This PR's CI run is the live verification** — it executes on the self-hosted runner; green checks = the conversion works end-to-end

Closes #97

🤖 ultraloop iteration 5
