### PR TITLE
ci: enforce 90% coverage gate + perf-budget regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
 
       - name: Coverage threshold check
         if: matrix.python-version == '3.12'
-        run: coverage report --fail-under=80
+        # 90% — reachable now that the self-hosted GPU runner runs the rendering
+        # tests (engine/export, filters, etc.) that GitHub-hosted CI must skip.
+        run: coverage report --fail-under=90
 
       - name: Test count regression guard
         if: matrix.python-version == '3.12'

--- a/e2e/reports/2026-06-16-62-quality-gates.md
+++ b/e2e/reports/2026-06-16-62-quality-gates.md
@@ -1,0 +1,45 @@
+# E2E Evidence — #62 Quality gates (90% coverage + benchmark regression)
+
+- **Date**: 2026-06-16
+- **Environment**: oliveeelab self-hosted runner, RTX 4090, EGL
+
+## Coverage gate 80% → 90%
+
+With the self-hosted GPU runner (#97) running the rendering tests that
+GitHub-hosted CI must skip, measured coverage is now well above the new gate:
+
+```
+1751 passed, 13 skipped
+TOTAL  5597 stmts, 275 missed → 95%
+```
+
+`ci.yml` coverage check raised to `--fail-under=90` (runs on Python 3.12, the
+version with `VIZNOIR_RUN_GPU_TESTS=1`). 95% ≥ 90% → the gate passes with margin.
+
+## Benchmark regression gate
+
+`tests/test_engine/test_perf_budget_vtk.py` — 4 render-latency budget tests that
+run on the self-hosted GPU runner (EGL) as part of the 3.12 test job. A render
+that suddenly takes seconds fails CI. Budgets are >10× typical to ignore the
+shared host's timing noise.
+
+| benchmark | typical | budget | headroom |
+|-----------|--------:|-------:|---------:|
+| wavelet render (1080p) | ~150 ms | 3000 ms | ~20× |
+| 480p render | ~30 ms | 1500 ms | ~50× |
+| 4K render | ~310 ms | 8000 ms | ~25× |
+| colormap switch | ~55 ms | 3000 ms | ~50× |
+
+Verified:
+```
+CI=1 VIZNOIR_RUN_GPU_TESTS=1 ...EGL...  -> 4 passed in 1.15s
+CI=1 (hosted, no GPU)                   -> 4 skipped
+```
+
+The perf tests are `*_vtk.py`, so they auto-skip on GitHub-hosted CI and run only
+where a GPU exists — same gating as the other rendering tests.
+
+## Result
+
+v0.11.0 "Trust & Guard" quality gates are enforced in CI: ≥90% coverage and
+bounded render latency, both on the self-hosted GPU runner. ruff + mypy clean.

--- a/tests/test_engine/test_perf_budget_vtk.py
+++ b/tests/test_engine/test_perf_budget_vtk.py
@@ -1,0 +1,61 @@
+"""Performance-budget regression tests — render latency must stay under budget.
+
+These render on the GPU, so they are skipped on GitHub-hosted CI (``*_vtk.py``)
+and run on the self-hosted runner where VIZNOIR_RUN_GPU_TESTS is set. Budgets are
+deliberately generous (>10x the typical measured latency) so they catch gross
+regressions — a render that suddenly takes seconds — without flaking on the
+shared host's normal timing noise.
+"""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+import pytest
+import vtk
+
+from viznoir.engine.renderer import RenderConfig, render_to_png
+
+
+def _wavelet() -> vtk.vtkImageData:
+    src = vtk.vtkRTAnalyticSource()
+    src.SetWholeExtent(-10, 10, -10, 10, -10, 10)
+    src.Update()
+    return src.GetOutput()
+
+
+@pytest.fixture(scope="module")
+def wavelet() -> vtk.vtkImageData:
+    data = _wavelet()
+    # Warm up the singleton render window so the first timed render isn't paying
+    # one-time GL/context init.
+    render_to_png(data, RenderConfig(array_name="RTData", width=256, height=256))
+    return data
+
+
+def _render_ms(data, config: RenderConfig) -> float:
+    t0 = perf_counter()
+    png = render_to_png(data, config)
+    dt = (perf_counter() - t0) * 1000.0
+    assert png[:4] == b"\x89PNG", "render did not produce a valid PNG"
+    return dt
+
+
+class TestRenderBudget:
+    def test_wavelet_render_budget(self, wavelet):
+        dt = _render_ms(wavelet, RenderConfig(array_name="RTData"))
+        assert dt < 3000.0, f"wavelet render {dt:.0f}ms exceeds 3000ms budget"
+
+    def test_low_res_render_budget(self, wavelet):
+        dt = _render_ms(wavelet, RenderConfig(array_name="RTData", width=480, height=270))
+        assert dt < 1500.0, f"480p render {dt:.0f}ms exceeds 1500ms budget"
+
+    def test_4k_render_budget(self, wavelet):
+        dt = _render_ms(wavelet, RenderConfig(array_name="RTData", width=3840, height=2160))
+        assert dt < 8000.0, f"4K render {dt:.0f}ms exceeds 8000ms budget"
+
+    def test_colormap_switch_budget(self, wavelet):
+        # switching colormaps must not blow up latency
+        for cmap in ("viridis", "coolwarm", "turbo"):
+            dt = _render_ms(wavelet, RenderConfig(array_name="RTData", colormap=cmap))
+            assert dt < 3000.0, f"{cmap} render {dt:.0f}ms exceeds 3000ms budget"


### PR DESCRIPTION
## Description
v0.11.0 "Trust & Guard" **quality gates** (#62) — now reachable because the self-hosted GPU runner (#97) runs the rendering tests GitHub-hosted CI must skip.

- **Coverage gate 80% → 90%**: `ci.yml` `coverage report --fail-under=90` (runs on Python 3.12 with `VIZNOIR_RUN_GPU_TESTS=1` → measured **95%**).
- **Benchmark regression gate**: `tests/test_engine/test_perf_budget_vtk.py` — 4 render-latency budget tests with >10× headroom over typical, run on the 3.12 self-hosted GPU job. A render that suddenly takes seconds fails CI. Auto-skip on hosted (`*_vtk.py`).

## Test Plan
- GPU coverage (local, `env -u CI`): **1751 passed, 95% TOTAL** ≥ 90% gate
- Perf tests: `CI=1 VIZNOIR_RUN_GPU_TESTS=1 ...EGL...` → 4 passed (1.15s); `CI=1` → 4 skipped (hosted behavior unchanged)
- `ruff` + `mypy` clean
- **This PR's CI run verifies the 90% gate on the self-hosted runner** (3.12 with GPU tests + perf budgets)
- Evidence: `e2e/reports/2026-06-16-62-quality-gates.md`

Closes #62

🤖 ultraloop iteration 6
