### PR TITLE
feat(api): SemVer + deprecation policy (enforced deprecation helper)

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,0 +1,70 @@
+# API Stability & Deprecation Policy
+
+From **v1.0.0**, viznoir follows [Semantic Versioning](https://semver.org/) for
+its **public API**. This document defines what "public" means, what stability we
+guarantee, and how things are deprecated and removed.
+
+## What is the public API
+
+The public, SemVer-covered surface is:
+
+| Surface | Contract |
+|---------|----------|
+| **MCP tools** | The 24 registered tools, their names, and their parameter names/types/defaults (see `docs/tools/`). |
+| **MCP resources** | `viznoir://` resource URIs and their schemas. |
+| **MCP prompts** | Registered prompt names and arguments. |
+| **Pipeline models** | `viznoir.pipeline.models` (`SourceDef`, `FilterStep`, `RenderDef`, `OutputDef`, `PipelineDefinition`) field names and types. |
+| **CLI** | The `mcp-server-viznoir` entry point and its behaviour. |
+| **Environment variables** | The documented `VIZNOIR_*` variables (see `CLAUDE.md` / README). |
+
+**Not public** (may change in any release): anything prefixed with `_`, the
+`viznoir.engine.*` internals, test fixtures, and benchmark scripts. Build on the
+MCP tools and pipeline models, not the engine internals.
+
+## SemVer guarantee
+
+- **PATCH** (`1.0.x`): bug fixes only. No public API changes.
+- **MINOR** (`1.x.0`): backward-compatible additions — new tools, new optional
+  parameters (with defaults), new resources. Existing calls keep working.
+- **MAJOR** (`x.0.0`): may remove or change public API, but only items that have
+  been through a full deprecation cycle (below).
+
+A call that works on `1.a.b` works on any `1.c.d` with `c.d >= a.b`.
+
+## Deprecation cycle
+
+Deprecations are **enforced in code**, not just documented, via
+`viznoir._deprecation`:
+
+```python
+from viznoir._deprecation import deprecated, warn_deprecated
+
+@deprecated(since="1.2.0", removed_in="2.0.0", alternative="new_tool")
+def old_tool(...): ...
+
+# for a single parameter or behaviour:
+warn_deprecated("legacy_param", since="1.2.0", removed_in="2.0.0", alternative="modern_param")
+```
+
+Lifecycle:
+
+1. **Deprecate** in a MINOR release — the item still works but emits a
+   `DeprecationWarning` naming the version, the removal target, and the
+   replacement.
+2. **Warn** for at least one full MINOR series so users have time to migrate.
+3. **Remove** only in the next MAJOR release.
+
+Run your client with `-W error::DeprecationWarning` to fail fast on anything
+deprecated.
+
+## Breaking-change checklist (maintainers)
+
+Before merging a change that touches the public surface:
+
+- [ ] Is it additive (new tool / optional param)? → MINOR, fine.
+- [ ] Does it change/remove existing public behaviour? → it must first ship as a
+      `@deprecated` / `warn_deprecated` shim in a MINOR, and only be removed in a
+      MAJOR.
+- [ ] Tool inventory/count tests (`tests/test_tools/test_server_registration.py`,
+      `test_mcp_compliance.py`) updated and still pinning the surface?
+- [ ] `CHANGELOG.md` entry (release-please) reflects the SemVer impact.

--- a/e2e/reports/2026-06-16-64-api-stability.md
+++ b/e2e/reports/2026-06-16-64-api-stability.md
@@ -1,0 +1,42 @@
+# E2E Evidence — #64 Stable API + SemVer & deprecation policy
+
+- **Date**: 2026-06-16
+- **Scenario**: `e2e/scenarios/api_stability_e2e.py`
+
+## What was delivered
+
+- `docs/api-stability.md` — defines the public API surface (24 MCP tools,
+  resources, prompts, `pipeline.models`, CLI, `VIZNOIR_*` env), the SemVer
+  guarantee (PATCH/MINOR/MAJOR), the deprecate→warn→remove cycle, and a
+  maintainer breaking-change checklist.
+- `viznoir/_deprecation.py` — `deprecated()` decorator + `warn_deprecated()` that
+  **enforce** the policy in code (consistent `DeprecationWarning` naming the
+  version, removal target, and replacement).
+
+## End-to-end demonstration
+
+```
+result='rendered'
+warning='legacy_render is deprecated since viznoir 1.0.0 and will be removed in 2.0.0. Use render instead.'
+```
+
+Checks (7/7 PASS):
+
+```
+[PASS] deprecated callable still returns      (no behaviour change)
+[PASS] emits DeprecationWarning
+[PASS] warning names since + removal           (1.0.0 / 2.0.0)
+[PASS] warning names replacement               (render)
+[PASS] carries __deprecated__ metadata
+[PASS] -W error makes it fail-fast             (clients can hard-fail on deprecated API)
+[PASS] api-stability.md exists                 (Semantic Versioning policy documented)
+```
+
+The public tool surface itself is already pinned by
+`tests/test_tools/test_server_registration.py` + `test_mcp_compliance.py` (name
+inventory + count), so the 1.0 freeze is test-enforced, not just documented.
+
+## Unit coverage
+
+`tests/test_deprecation.py` — 7 tests, `_deprecation.py` at **100%**. Suite: 1771
+tests. ruff + mypy (89 files) clean.

--- a/e2e/scenarios/api_stability_e2e.py
+++ b/e2e/scenarios/api_stability_e2e.py
@@ -1,0 +1,61 @@
+"""E2E evidence for #64 — the deprecation policy is enforced in code, end to end.
+
+Shows that a @deprecated public callable (1) still works, (2) emits a
+DeprecationWarning naming the version + replacement a user would act on, and
+(3) can be made fail-fast with -W error::DeprecationWarning.
+
+Run:  .venv/bin/python e2e/scenarios/api_stability_e2e.py
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+from viznoir._deprecation import deprecated
+
+
+@deprecated(since="1.0.0", removed_in="2.0.0", alternative="render")
+def legacy_render() -> str:
+    return "rendered"
+
+
+def main() -> int:
+    doc = Path(__file__).resolve().parents[2] / "docs" / "api-stability.md"
+
+    # 1) still works + emits a warning
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = legacy_render()
+    warn = caught[0].message if caught else None
+    print(f"result={result!r}")
+    print(f"warning={str(warn)!r}")
+
+    # 2) fail-fast mode turns it into an error
+    failed_fast = False
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        try:
+            legacy_render()
+        except DeprecationWarning:
+            failed_fast = True
+
+    checks = {
+        "deprecated callable still returns": result == "rendered",
+        "emits DeprecationWarning": isinstance(warn, DeprecationWarning),
+        "warning names since + removal": warn and "1.0.0" in str(warn) and "2.0.0" in str(warn),
+        "warning names replacement": warn and "render" in str(warn),
+        "carries __deprecated__ metadata": legacy_render.__deprecated__["removed_in"] == "2.0.0",
+        "-W error makes it fail-fast": failed_fast,
+        "api-stability.md exists": doc.is_file() and "Semantic Versioning" in doc.read_text(),
+    }
+    ok = True
+    for name, passed in checks.items():
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
+        ok = ok and bool(passed)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/viznoir/_deprecation.py
+++ b/src/viznoir/_deprecation.py
@@ -1,0 +1,67 @@
+"""Deprecation utilities backing the v1.0 SemVer + deprecation policy.
+
+Public API marked with :func:`deprecated` (or signalled via
+:func:`warn_deprecated`) emits a ``DeprecationWarning`` naming the version it was
+deprecated in, when it will be removed, and the replacement — so the deprecation
+cycle documented in ``docs/api-stability.md`` is enforced in code, not just prose.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _message(name: str, since: str, removed_in: str, alternative: str | None) -> str:
+    msg = f"{name} is deprecated since viznoir {since} and will be removed in {removed_in}."
+    if alternative:
+        msg += f" Use {alternative} instead."
+    return msg
+
+
+def deprecated(since: str, removed_in: str, alternative: str | None = None) -> Callable[[F], F]:
+    """Mark a public callable as deprecated.
+
+    Calling the decorated function emits a ``DeprecationWarning`` and attaches a
+    ``__deprecated__`` metadata dict; the original behaviour is otherwise
+    unchanged.
+
+    Args:
+        since: version the deprecation started (e.g. ``"1.0.0"``).
+        removed_in: version it will be removed in (e.g. ``"2.0.0"``).
+        alternative: the replacement to point users to.
+    """
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(
+                _message(func.__qualname__, since, removed_in, alternative),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        wrapper.__deprecated__ = {  # type: ignore[attr-defined]
+            "since": since,
+            "removed_in": removed_in,
+            "alternative": alternative,
+        }
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def warn_deprecated(
+    name: str,
+    since: str,
+    removed_in: str,
+    alternative: str | None = None,
+    stacklevel: int = 2,
+) -> None:
+    """Emit a deprecation warning for a parameter or behaviour (not a whole callable)."""
+    warnings.warn(_message(name, since, removed_in, alternative), DeprecationWarning, stacklevel=stacklevel)

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,71 @@
+"""Tests for viznoir._deprecation — enforces the v1.0 deprecation policy."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from viznoir._deprecation import deprecated, warn_deprecated
+
+
+class TestDeprecatedDecorator:
+    def test_emits_deprecation_warning(self):
+        @deprecated(since="1.0.0", removed_in="2.0.0")
+        def old():
+            return 42
+
+        with pytest.warns(DeprecationWarning) as record:
+            assert old() == 42
+        assert len(record) == 1
+        msg = str(record[0].message)
+        assert "1.0.0" in msg and "2.0.0" in msg
+
+    def test_includes_alternative(self):
+        @deprecated(since="1.0.0", removed_in="2.0.0", alternative="new_func")
+        def old():
+            return None
+
+        with pytest.warns(DeprecationWarning, match="new_func"):
+            old()
+
+    def test_preserves_metadata(self):
+        @deprecated(since="1.0.0", removed_in="2.0.0")
+        def documented():
+            """Original docstring."""
+            return 1
+
+        assert documented.__name__ == "documented"
+        assert documented.__doc__ == "Original docstring."
+
+    def test_attaches_deprecation_info(self):
+        @deprecated(since="1.0.0", removed_in="2.0.0", alternative="x")
+        def f():
+            return 0
+
+        assert f.__deprecated__ == {
+            "since": "1.0.0",
+            "removed_in": "2.0.0",
+            "alternative": "x",
+        }
+
+    def test_return_value_passthrough(self):
+        @deprecated(since="1.0.0", removed_in="2.0.0")
+        def add(a, b):
+            return a + b
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            assert add(2, 3) == 5
+
+
+class TestWarnDeprecated:
+    def test_emits_for_named_thing(self):
+        with pytest.warns(DeprecationWarning, match="old_param"):
+            warn_deprecated("old_param", since="1.0.0", removed_in="2.0.0")
+
+    def test_message_mentions_versions_and_alternative(self):
+        with pytest.warns(DeprecationWarning) as record:
+            warn_deprecated("p", since="1.0.0", removed_in="2.0.0", alternative="q")
+        msg = str(record[0].message)
+        assert "1.0.0" in msg and "2.0.0" in msg and "q" in msg


### PR DESCRIPTION
## Description
First v1.0.0 card (#64) — commit to a **stable public API** with SemVer and an **enforced** deprecation policy.

- `docs/api-stability.md` — defines the public surface (24 MCP tools, resources, prompts, `pipeline.models`, CLI, `VIZNOIR_*` env), the SemVer guarantee (PATCH/MINOR/MAJOR), the deprecate→warn→remove cycle, and a maintainer breaking-change checklist.
- `viznoir/_deprecation.py` — `deprecated()` decorator + `warn_deprecated()` that enforce the policy in code: a consistent `DeprecationWarning` naming the version, removal target, and replacement, plus `__deprecated__` metadata.

The tool surface is already pinned by `test_server_registration.py` + `test_mcp_compliance.py` (name inventory + count), so the 1.0 freeze is **test-enforced**, not just prose.

## Test Plan
- `tests/test_deprecation.py` — **7 tests**, `_deprecation.py` at **100%**
- Suite **1771 tests**; `ruff` + `mypy` (89 files) clean
- **E2E** — `e2e/scenarios/api_stability_e2e.py`: a `@deprecated` callable still returns, emits a `DeprecationWarning` (`"...deprecated since viznoir 1.0.0 and will be removed in 2.0.0. Use render instead."`), and `-W error::DeprecationWarning` fail-fasts. 7/7 pass. Report: `e2e/reports/2026-06-16-64-api-stability.md`

Closes #64

🤖 ultraloop iteration 8
