### PR TITLE
feat(plugins): entry-point plugin system (filters/parsers/presets)

### DIFF
--- a/e2e/reports/2026-06-16-66-plugin-system.md
+++ b/e2e/reports/2026-06-16-66-plugin-system.md
@@ -1,0 +1,41 @@
+# E2E Evidence — #66 Plugin system (entry-point discovery)
+
+- **Date**: 2026-06-16
+- **Scenario**: `e2e/scenarios/plugin_system_e2e.py`
+
+## What was delivered
+
+`viznoir/plugins.py` — `load_plugins()` discovers setuptools entry points in
+three groups and registers them into viznoir's registries; one broken plugin is
+warned-and-skipped, never blocking the others or the server:
+
+| group | registers into | via |
+|-------|----------------|-----|
+| `viznoir.filters` | `engine.filters._FILTER_REGISTRY` | new `register_filter()` |
+| `viznoir.parsers` | context parser registry (before the Generic fallback) | new `register_plugin_parser()` |
+| `viznoir.presets` | `presets.registry.CASE_PRESETS` | new `register_preset()` |
+
+Wired into `server.main()` so plugins load at startup (failures logged, never fatal).
+
+## End-to-end demonstration (real install, no mocks)
+
+The scenario builds a throwaway package declaring real entry points,
+`pip install`s it into the venv, then in a **fresh subprocess** runs the real
+`importlib.metadata` discovery path:
+
+```
+LOADED ['demo_passthrough'] ['demo_case']
+  [PASS] real entry-point plugin discovered + registered + callable
+```
+
+- the `viznoir.filters` entry point appears in `list_filters()` and is invocable
+  via `apply_filter(data, "demo_passthrough")`
+- the `viznoir.presets` entry point appears in `CASE_PRESETS`
+- the package is uninstalled afterwards (no residue)
+
+## Unit coverage
+
+`tests/test_plugins.py` — 8 tests (fake entry points exercise registration +
+graceful-failure isolation), `plugins.py` at **100%**. Existing parser/filter/
+preset tests still pass (231 related). Suite: 1779 tests. ruff + mypy (90 files)
+clean.

--- a/e2e/scenarios/plugin_system_e2e.py
+++ b/e2e/scenarios/plugin_system_e2e.py
@@ -1,0 +1,101 @@
+"""E2E evidence for #66 — discover a REAL installed plugin via entry points.
+
+Builds a throwaway plugin package that declares viznoir.filters / viznoir.presets
+entry points, pip-installs it into the venv, then (in a fresh subprocess so the
+entry points are visible) runs load_plugins() through the *real*
+importlib.metadata path — no monkeypatching — and verifies the filter and preset
+are registered and usable. Uninstalls the package afterwards.
+
+Run:  .venv/bin/python e2e/scenarios/plugin_system_e2e.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PY = sys.executable  # the venv python running this script
+PKG = "viznoir-e2e-demo-plugin"
+
+PYPROJECT = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "viznoir-e2e-demo-plugin"
+version = "0.0.0"
+
+[project.entry-points."viznoir.filters"]
+demo_passthrough = "viznoir_e2e_demo_plugin:passthrough"
+
+[project.entry-points."viznoir.presets"]
+demo_case = "viznoir_e2e_demo_plugin:DEMO_PRESET"
+
+[tool.hatch.build.targets.wheel]
+packages = ["viznoir_e2e_demo_plugin"]
+"""
+
+MODULE = '''\
+"""Throwaway viznoir plugin for E2E."""
+
+def passthrough(data, **kwargs):
+    """A trivial filter: return the dataset unchanged."""
+    return data
+
+DEMO_PRESET = {"description": "e2e demo preset", "fields": {}}
+'''
+
+# Runs inside the subprocess (after install) — exercises the real discovery path.
+VERIFY = """
+import sys
+from viznoir.plugins import load_plugins
+from viznoir.engine.filters import list_filters, apply_filter
+from viznoir.presets.registry import CASE_PRESETS
+
+loaded = load_plugins()
+ok = True
+ok &= "demo_passthrough" in loaded["viznoir.filters"]
+ok &= "demo_passthrough" in list_filters()
+ok &= "demo_case" in loaded["viznoir.presets"]
+ok &= CASE_PRESETS.get("demo_case", {}).get("description") == "e2e demo preset"
+# the registered filter is actually callable through apply_filter
+sentinel = object()
+ok &= apply_filter(sentinel, "demo_passthrough") is sentinel
+print("LOADED", loaded["viznoir.filters"], loaded["viznoir.presets"])
+sys.exit(0 if ok else 1)
+"""
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "viznoir_e2e_demo_plugin").mkdir()
+        (root / "viznoir_e2e_demo_plugin" / "__init__.py").write_text(MODULE)
+        (root / "pyproject.toml").write_text(PYPROJECT)
+
+        install = subprocess.run(
+            ["uv", "pip", "install", "--python", PY, "--no-deps", str(root)],
+            capture_output=True, text=True,
+        )
+        if install.returncode != 0:
+            print("install failed:", install.stderr[-400:])
+            return 1
+        try:
+            verify = subprocess.run([PY, "-c", VERIFY], capture_output=True, text=True)
+            print(verify.stdout.strip() or verify.stderr.strip()[-400:])
+            passed = verify.returncode == 0
+        finally:
+            subprocess.run(
+                ["uv", "pip", "uninstall", "--python", PY, PKG],
+                capture_output=True, text=True,
+            )
+
+    print(f"  [{'PASS' if passed else 'FAIL'}] real entry-point plugin discovered + registered + callable")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/viznoir/context/parser.py
+++ b/src/viznoir/context/parser.py
@@ -36,6 +36,16 @@ class ContextParserRegistry:
         return None
 
 
+# Parsers registered by plugins (viznoir.parsers entry points). Checked after the
+# built-in specific parsers but before the Generic catch-all fallback.
+_PLUGIN_PARSERS: list[ContextParser] = []
+
+
+def register_plugin_parser(parser: ContextParser) -> None:
+    """Register a context parser contributed by a plugin (see viznoir.plugins)."""
+    _PLUGIN_PARSERS.append(parser)
+
+
 def get_default_registry() -> ContextParserRegistry:
     """Create registry with built-in parsers (OpenFOAM first, Generic as fallback)."""
     from viznoir.context.cgns import CGNSContextParser
@@ -48,6 +58,9 @@ def get_default_registry() -> ContextParserRegistry:
     registry.register(OpenFOAMContextParser())
     registry.register(CGNSContextParser())
     registry.register(DualSPHysicsContextParser())
+    # Plugin parsers — after built-ins, before the Generic catch-all
+    for parser in _PLUGIN_PARSERS:
+        registry.register(parser)
     # Generic is fallback — always returns True for can_parse
     registry.register(GenericContextParser())
     return registry

--- a/src/viznoir/engine/filters.py
+++ b/src/viznoir/engine/filters.py
@@ -1025,3 +1025,13 @@ def apply_filters(
 def list_filters() -> list[str]:
     """Return sorted list of available filter names."""
     return sorted(_FILTER_REGISTRY.keys())
+
+
+def register_filter(name: str, func: object) -> None:
+    """Register a filter function (e.g. from a plugin — see viznoir.plugins).
+
+    ``func`` must accept ``(data, **kwargs)`` and return a VTK dataset, matching
+    the built-in filters. The name is normalized so CamelCase/snake_case both
+    resolve via :func:`apply_filter`.
+    """
+    _FILTER_REGISTRY[_normalize_filter_name(name)] = func

--- a/src/viznoir/plugins.py
+++ b/src/viznoir/plugins.py
@@ -1,0 +1,74 @@
+"""Plugin discovery — load user filters, parsers, and presets from entry points.
+
+Users extend viznoir without forking by declaring setuptools entry points:
+
+    [project.entry-points."viznoir.filters"]
+    my_filter = "my_pkg:my_filter_func"      # callable(data, **kwargs) -> dataset
+
+    [project.entry-points."viznoir.parsers"]
+    my_parser = "my_pkg:MyParser"            # ContextParser instance or class
+
+    [project.entry-points."viznoir.presets"]
+    my_case = "my_pkg:MY_PRESET"             # case-preset dict
+
+:func:`load_plugins` discovers and registers them into viznoir's registries. A
+single broken plugin is logged and skipped — it never blocks the others or the
+server.
+"""
+
+from __future__ import annotations
+
+import warnings
+from importlib.metadata import entry_points
+
+# Entry-point groups viznoir looks up.
+FILTER_GROUP = "viznoir.filters"
+PARSER_GROUP = "viznoir.parsers"
+PRESET_GROUP = "viznoir.presets"
+
+
+def _register_filter(name: str, obj: object) -> None:
+    from viznoir.engine.filters import register_filter
+
+    register_filter(name, obj)
+
+
+def _register_parser(name: str, obj: object) -> None:
+    from viznoir.context.parser import register_plugin_parser
+
+    parser = obj() if isinstance(obj, type) else obj
+    register_plugin_parser(parser)  # type: ignore[arg-type]  # runtime-checked Protocol
+
+
+def _register_preset(name: str, obj: object) -> None:
+    from viznoir.presets.registry import register_preset
+
+    register_preset(name, obj)  # type: ignore[arg-type]
+
+
+_GROUPS = {
+    FILTER_GROUP: _register_filter,
+    PARSER_GROUP: _register_parser,
+    PRESET_GROUP: _register_preset,
+}
+
+
+def load_plugins() -> dict[str, list[str]]:
+    """Discover and register all viznoir plugins from entry points.
+
+    Returns a ``{group: [registered names]}`` map. Plugins that fail to load or
+    register emit a ``UserWarning`` and are skipped.
+    """
+    loaded: dict[str, list[str]] = {group: [] for group in _GROUPS}
+    for group, register in _GROUPS.items():
+        for ep in entry_points(group=group):
+            try:
+                register(ep.name, ep.load())
+            except Exception as exc:  # noqa: BLE001 — one bad plugin must not break others
+                warnings.warn(
+                    f"viznoir: failed to load plugin '{ep.name}' from '{group}': {exc}",
+                    stacklevel=2,
+                )
+                continue
+            loaded[group].append(ep.name)
+    return loaded

--- a/src/viznoir/presets/registry.py
+++ b/src/viznoir/presets/registry.py
@@ -454,3 +454,8 @@ def get_preset(case_type: str) -> dict[str, Any]:
 def list_presets() -> dict[str, str]:
     """Return {case_type: description} for all available presets."""
     return {k: v["description"] for k, v in CASE_PRESETS.items()}
+
+
+def register_preset(case_type: str, preset: dict[str, Any]) -> None:
+    """Register a case preset (e.g. from a plugin — see viznoir.plugins)."""
+    CASE_PRESETS[case_type] = preset

--- a/src/viznoir/server.py
+++ b/src/viznoir/server.py
@@ -1431,6 +1431,17 @@ def main() -> None:
 
     # Resources and prompts are already registered at module level above.
 
+    # Discover and register third-party plugins (filters/parsers/presets).
+    try:
+        from viznoir.plugins import load_plugins
+
+        loaded = load_plugins()
+        n = sum(len(v) for v in loaded.values())
+        if n:
+            logger.info("loaded %d plugin(s): %s", n, loaded)
+    except Exception:  # noqa: BLE001 — plugin discovery must never block startup
+        logger.warning("plugin discovery failed", exc_info=True)
+
     if args.transport == "stdio":
         mcp.run()
     elif args.transport == "sse":

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,124 @@
+"""Tests for viznoir.plugins — entry-point plugin discovery.
+
+Fake EntryPoint objects are injected via monkeypatch so the real registration
+paths are exercised without installing an external package.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import viznoir.plugins as plugins
+from viznoir.context.parser import get_default_registry
+from viznoir.engine.filters import list_filters
+from viznoir.presets.registry import CASE_PRESETS
+
+
+class _FakeEP:
+    def __init__(self, name, obj=None, error=None):
+        self.name = name
+        self._obj = obj
+        self._error = error
+
+    def load(self):
+        if self._error is not None:
+            raise self._error
+        return self._obj
+
+
+def _patch_eps(monkeypatch, mapping):
+    """mapping: {group: [FakeEP, ...]}"""
+
+    def fake_entry_points(group):
+        return mapping.get(group, [])
+
+    monkeypatch.setattr(plugins, "entry_points", fake_entry_points)
+
+
+def _noop_filter(data, **kwargs):
+    return data
+
+
+class _FakeParser:
+    def can_parse(self, path):
+        return path.endswith(".fake")
+
+    def parse_dataset(self, dataset):
+        return None
+
+
+@pytest.fixture
+def clean_registries():
+    yield
+    # remove anything a test registered
+    from viznoir.context import parser as parser_mod
+    from viznoir.engine import filters as filters_mod
+
+    filters_mod._FILTER_REGISTRY.pop("plugin_filter", None)
+    CASE_PRESETS.pop("plugin_case", None)
+    parser_mod._PLUGIN_PARSERS.clear()
+
+
+class TestLoadPlugins:
+    def test_registers_filter(self, monkeypatch, clean_registries):
+        _patch_eps(monkeypatch, {"viznoir.filters": [_FakeEP("plugin_filter", _noop_filter)]})
+        loaded = plugins.load_plugins()
+        assert "plugin_filter" in loaded["viznoir.filters"]
+        assert "plugin_filter" in list_filters()
+
+    def test_registers_preset(self, monkeypatch, clean_registries):
+        preset = {"description": "plugin", "fields": {}}
+        _patch_eps(monkeypatch, {"viznoir.presets": [_FakeEP("plugin_case", preset)]})
+        plugins.load_plugins()
+        assert CASE_PRESETS["plugin_case"] == preset
+
+    def test_registers_parser_instance_and_class(self, monkeypatch, clean_registries):
+        _patch_eps(
+            monkeypatch,
+            {"viznoir.parsers": [_FakeEP("inst", _FakeParser()), _FakeEP("cls", _FakeParser)]},
+        )
+        plugins.load_plugins()
+        reg = get_default_registry()
+        assert reg.get_parser("x.fake") is not None  # plugin parser handles .fake
+
+    def test_bad_plugin_warns_and_others_load(self, monkeypatch, clean_registries):
+        _patch_eps(
+            monkeypatch,
+            {
+                "viznoir.filters": [
+                    _FakeEP("broken", error=RuntimeError("boom")),
+                    _FakeEP("plugin_filter", _noop_filter),
+                ]
+            },
+        )
+        with pytest.warns(UserWarning, match="broken"):
+            loaded = plugins.load_plugins()
+        assert loaded["viznoir.filters"] == ["plugin_filter"]
+        assert "plugin_filter" in list_filters()
+
+    def test_no_plugins_is_empty(self, monkeypatch):
+        _patch_eps(monkeypatch, {})
+        loaded = plugins.load_plugins()
+        assert loaded == {"viznoir.filters": [], "viznoir.parsers": [], "viznoir.presets": []}
+
+
+class TestRegisterHelpers:
+    def test_register_filter(self, clean_registries):
+        from viznoir.engine.filters import register_filter
+
+        register_filter("plugin_filter", _noop_filter)
+        assert "plugin_filter" in list_filters()
+
+    def test_register_preset(self, clean_registries):
+        from viznoir.presets.registry import register_preset
+
+        register_preset("plugin_case", {"description": "x"})
+        assert "plugin_case" in CASE_PRESETS
+
+    def test_register_plugin_parser_used_before_generic(self, clean_registries):
+        from viznoir.context.parser import register_plugin_parser
+
+        register_plugin_parser(_FakeParser())
+        reg = get_default_registry()
+        # plugin parser must win over the Generic fallback for its file type
+        assert reg.get_parser("sim.fake").__class__.__name__ == "_FakeParser"


### PR DESCRIPTION
## Description
Plugin system (#66) — let users register their own **filters / context parsers / presets** without forking, via setuptools entry points.

| group | registers into |
|-------|----------------|
| `viznoir.filters` | `engine.filters` (new `register_filter`) |
| `viznoir.parsers` | context parser registry, before the Generic fallback (new `register_plugin_parser`) |
| `viznoir.presets` | `presets.registry.CASE_PRESETS` (new `register_preset`) |

`viznoir/plugins.py:load_plugins()` discovers + registers them; one broken plugin is **warned-and-skipped**, never blocking others. Wired into `server.main()` (failures logged, never fatal).

## Test Plan
- `tests/test_plugins.py` — **8 tests** (fake entry points exercise the real registration paths + graceful-failure isolation), `plugins.py` **100%**
- 231 related parser/filter/preset tests still pass (no regression from the new register helpers); suite **1779 tests**; `ruff` + `mypy` (90 files) clean
- **E2E (real install, no mocks)** — `e2e/scenarios/plugin_system_e2e.py` builds a throwaway package with real entry points, `pip install`s it, and in a fresh subprocess confirms via the real `importlib.metadata` path that the filter is discovered, registered, callable through `apply_filter`, and the preset lands in `CASE_PRESETS`. Report: `e2e/reports/2026-06-16-66-plugin-system.md`

Closes #66

🤖 ultraloop iteration 9
