### PR TITLE
feat(remote): WebSocket render server streaming orbit frames

### DIFF
--- a/e2e/reports/2026-06-16-67-remote-render.md
+++ b/e2e/reports/2026-06-16-67-remote-render.md
@@ -1,0 +1,43 @@
+# E2E Evidence — #67 Remote render (WebSocket streaming)
+
+- **Date**: 2026-06-16
+- **Scenario**: `e2e/scenarios/remote_render_e2e.py` (+ `tests/test_remote_vtk.py`)
+- **Environment**: oliveeelab self-hosted, RTX 4090, EGL
+
+## What was delivered
+
+`viznoir/remote.py` — a WebSocket render server that streams rendered frames from
+the GPU host:
+
+- client sends a JSON request (`file_path`, `field_name`, `colormap`, `frames`/`azimuths`)
+- server renders an **orbit** of camera azimuths through the renderer singleton
+  and streams each frame back as a binary PNG, ending with `{"done": true, "frames": n}`
+- a malformed request gets `{"error": ...}` and the connection stays open
+- renders run synchronously on the event-loop thread (VTK is thread-affine; the
+  shared GPU singleton serializes renders anyway)
+
+Run it with `python -m viznoir.remote --host 0.0.0.0 --port 14100`.
+
+## End-to-end demonstration (real socket, real GPU renders)
+
+```
+received 3 frame(s), sizes=[131422, 240696, 189016] bytes
+done message: {'done': True, 'frames': 3}
+  [PASS] 3 frames streamed over WebSocket
+  [PASS] every frame is a valid PNG
+  [PASS] frames are non-trivial renders
+  [PASS] done summary correct
+```
+
+The three frames have different sizes because they are genuinely different camera
+angles of the orbit — confirming real rendering, not a cached/echoed payload.
+
+## Tests
+
+- `tests/test_remote.py` — 11 unit tests (parse/expand/stream/handler) with a fake
+  websocket + fake render_fn (no GPU/socket)
+- `tests/test_remote_vtk.py` — 2 GPU tests: `_default_render_fn` produces a real
+  PNG, and a full real-WebSocket roundtrip streams an orbit (runs on the
+  self-hosted GPU job)
+- `remote.py` at **100%** coverage (transport via unit tests, render+serve via the
+  GPU tests, CLI `pragma: no cover`). mypy clean.

--- a/e2e/scenarios/remote_render_e2e.py
+++ b/e2e/scenarios/remote_render_e2e.py
@@ -1,0 +1,86 @@
+"""E2E evidence for #67 — stream orbit frames over a real WebSocket with real renders.
+
+Starts the viznoir remote render server, connects a real WebSocket client, and
+requests a 3-frame orbit of a VTK wavelet — verifying real PNG frames arrive over
+the wire. Needs EGL/GPU.
+
+Run:  VTK_DEFAULT_OPENGL_WINDOW=vtkEGLRenderWindow .venv/bin/python e2e/scenarios/remote_render_e2e.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk
+
+from viznoir.remote import serve
+
+
+def _write_vti(path: str) -> None:
+    n = 8
+    img = vtk.vtkImageData()
+    img.SetDimensions(n, n, n)
+    arr = numpy_to_vtk(np.linspace(0.0, 255.0, n * n * n).astype(np.float64), deep=True)
+    arr.SetName("RTData")
+    img.GetPointData().AddArray(arr)
+    w = vtk.vtkXMLImageDataWriter()
+    w.SetFileName(path)
+    w.SetInputData(img)
+    w.Write()
+
+
+async def main() -> int:
+    import websockets
+
+    path = str(Path(tempfile.mkdtemp()) / "w.vti")
+    _write_vti(path)
+    port = 14241
+    server = asyncio.create_task(serve(host="127.0.0.1", port=port))
+    frames: list[bytes] = []
+    done = None
+    try:
+        for _ in range(50):
+            try:
+                conn = await websockets.connect(f"ws://127.0.0.1:{port}")
+                break
+            except OSError:
+                await asyncio.sleep(0.1)
+        async with conn:
+            await conn.send(json.dumps({"file_path": path, "field_name": "RTData", "frames": 3}))
+            while True:
+                msg = await asyncio.wait_for(conn.recv(), timeout=30)
+                if isinstance(msg, (bytes, bytearray)):
+                    frames.append(msg)
+                else:
+                    done = json.loads(msg)
+                    break
+    finally:
+        server.cancel()
+        try:
+            await server
+        except asyncio.CancelledError:
+            pass
+
+    print(f"received {len(frames)} frame(s), sizes={[len(f) for f in frames]} bytes")
+    print(f"done message: {done}")
+    checks = {
+        "3 frames streamed over WebSocket": len(frames) == 3,
+        "every frame is a valid PNG": all(f[:4] == b"\x89PNG" for f in frames),
+        "frames are non-trivial renders": all(len(f) > 1000 for f in frames),
+        "done summary correct": done == {"done": True, "frames": 3},
+    }
+    ok = True
+    for name, passed in checks.items():
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
+        ok = ok and passed
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/e2e/scenarios/remote_render_e2e.py
+++ b/e2e/scenarios/remote_render_e2e.py
@@ -45,12 +45,15 @@ async def main() -> int:
     frames: list[bytes] = []
     done = None
     try:
+        conn = None
         for _ in range(50):
             try:
                 conn = await websockets.connect(f"ws://127.0.0.1:{port}")
                 break
             except OSError:
                 await asyncio.sleep(0.1)
+        if conn is None:
+            raise RuntimeError("remote render server did not start")
         async with conn:
             await conn.send(json.dumps({"file_path": path, "field_name": "RTData", "frames": 3}))
             while True:
@@ -65,7 +68,7 @@ async def main() -> int:
         try:
             await server
         except asyncio.CancelledError:
-            pass
+            pass  # expected — we cancelled the server task
 
     print(f"received {len(frames)} frame(s), sizes={[len(f) for f in frames]} bytes")
     print(f"done message: {done}")

--- a/src/viznoir/remote.py
+++ b/src/viznoir/remote.py
@@ -1,0 +1,134 @@
+"""WebSocket remote render — stream rendered frames from a GPU host.
+
+A thin WebSocket server: a client sends a JSON render request, the server renders
+each requested frame (an orbit of camera azimuths) through the renderer singleton
+and streams the PNG bytes back as binary messages, finishing with a small JSON
+``{"done": true, "frames": n}``. A malformed request gets a JSON ``{"error": ...}``
+and the connection stays open.
+
+The frame-producing core takes an injected ``render_fn`` so the transport is
+testable without a GPU or a real socket; ``_default_render_fn`` is the real
+renderer path used by :func:`serve`.
+
+Run:  python -m viznoir.remote --host 0.0.0.0 --port 14100
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+from viznoir.logging import get_logger
+
+logger = get_logger("remote")
+
+RenderFn = Callable[[dict[str, Any]], bytes]
+
+_BASE_KEYS = ("file_path", "field_name", "association", "colormap", "scalar_range", "timestep")
+
+
+def parse_request(raw: str | bytes) -> dict[str, Any]:
+    """Parse and validate a render-request message. Raises ValueError on bad input."""
+    try:
+        req = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError(f"invalid JSON: {exc}") from exc
+    if not isinstance(req, dict) or "file_path" not in req:
+        raise ValueError("render request requires a 'file_path'")
+    return req
+
+
+def expand_frames(req: dict[str, Any]) -> list[dict[str, Any]]:
+    """Expand a request into per-frame parameter dicts (an orbit of azimuths)."""
+    base = {k: req[k] for k in _BASE_KEYS if k in req}
+    azimuths = req.get("azimuths")
+    if azimuths:
+        return [{**base, "azimuth": a} for a in azimuths]
+    n = int(req.get("frames", 1))
+    if n > 1:
+        return [{**base, "azimuth": 360.0 * i / n} for i in range(n)]
+    return [{**base, "azimuth": req.get("azimuth", 0.0)}]
+
+
+async def render_frames(req: dict[str, Any], render_fn: RenderFn) -> AsyncIterator[bytes]:
+    """Yield one PNG (bytes) per frame.
+
+    Renders run synchronously on the event-loop thread: VTK's render window is
+    thread-affine, and the shared GPU singleton serializes renders anyway, so a
+    render server processes one frame at a time rather than risking a cross-thread
+    OpenGL context crash.
+    """
+    for frame_params in expand_frames(req):
+        yield render_fn(frame_params)
+
+
+async def handle_connection(websocket: Any, render_fn: RenderFn) -> None:
+    """Serve one client: stream frames per request; report errors as JSON."""
+    async for message in websocket:
+        try:
+            req = parse_request(message)
+        except ValueError as exc:
+            await websocket.send(json.dumps({"error": str(exc)}))
+            continue
+        count = 0
+        async for frame in render_frames(req, render_fn):
+            await websocket.send(frame)
+            count += 1
+        await websocket.send(json.dumps({"done": True, "frames": count}))
+
+
+def _default_render_fn(params: dict[str, Any]) -> bytes:
+    """Render one orbit frame of a dataset to PNG (the real GPU path)."""
+    from viznoir.engine.camera import CameraConfig
+    from viznoir.engine.readers import read_dataset
+    from viznoir.engine.renderer import RenderConfig, render_to_png
+
+    data = read_dataset(params["file_path"], timestep=params.get("timestep"))
+    b = data.GetBounds()
+    center = ((b[0] + b[1]) / 2.0, (b[2] + b[3]) / 2.0, (b[4] + b[5]) / 2.0)
+    diag = math.sqrt((b[1] - b[0]) ** 2 + (b[3] - b[2]) ** 2 + (b[5] - b[4]) ** 2) or 1.0
+    rad = math.radians(float(params.get("azimuth", 0.0)))
+    dist = diag * 2.0
+    position = (
+        center[0] + dist * math.cos(rad) * 0.7,
+        center[1] + dist * math.sin(rad) * 0.7,
+        center[2] + dist * 0.5,
+    )
+    camera = CameraConfig(position=position, focal_point=center, view_up=(0.0, 0.0, 1.0))
+    config = RenderConfig(
+        array_name=params.get("field_name"),
+        colormap=params.get("colormap", "cool to warm"),
+        scalar_range=tuple(params["scalar_range"]) if params.get("scalar_range") else None,
+    )
+    return render_to_png(data, config, camera_config=camera)
+
+
+async def serve(host: str = "127.0.0.1", port: int = 14100, render_fn: RenderFn | None = None) -> None:
+    """Run the WebSocket render server until cancelled."""
+    import websockets
+
+    fn = render_fn or _default_render_fn
+
+    async def handler(ws: Any) -> None:
+        await handle_connection(ws, fn)
+
+    logger.info("viznoir remote render server on ws://%s:%d", host, port)
+    async with websockets.serve(handler, host, port):
+        await asyncio.Future()  # run forever
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    import argparse
+
+    ap = argparse.ArgumentParser(description="viznoir WebSocket remote render server")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=14100)
+    args = ap.parse_args()
+    asyncio.run(serve(host=args.host, port=args.port))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,106 @@
+"""Tests for viznoir.remote — WebSocket render streaming transport.
+
+A fake websocket + fake render_fn exercise the streaming logic without a GPU or
+a real socket.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from viznoir.remote import (
+    expand_frames,
+    handle_connection,
+    parse_request,
+    render_frames,
+)
+
+
+class _FakeWS:
+    """Minimal async websocket double: iterates given messages, records sends."""
+
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.sent: list = []
+
+    def __aiter__(self):
+        async def gen():
+            for m in self._messages:
+                yield m
+
+        return gen()
+
+    async def send(self, data):
+        self.sent.append(data)
+
+
+def _fake_render(params):
+    return b"\x89PNG" + str(params.get("azimuth", 0)).encode()
+
+
+# --------------------------------------------------------------------------- #
+class TestParseRequest:
+    def test_valid(self):
+        req = parse_request('{"file_path": "/x.vti", "field_name": "p"}')
+        assert req["file_path"] == "/x.vti"
+
+    def test_requires_file_path(self):
+        with pytest.raises(ValueError):
+            parse_request('{"field_name": "p"}')
+
+    def test_bad_json(self):
+        with pytest.raises(ValueError):
+            parse_request("not json{")
+
+
+class TestExpandFrames:
+    def test_single_default(self):
+        frames = expand_frames({"file_path": "/x", "field_name": "p"})
+        assert len(frames) == 1
+
+    def test_orbit_count(self):
+        frames = expand_frames({"file_path": "/x", "frames": 4})
+        assert len(frames) == 4
+        assert [f["azimuth"] for f in frames] == [0.0, 90.0, 180.0, 270.0]
+
+    def test_explicit_azimuths(self):
+        frames = expand_frames({"file_path": "/x", "azimuths": [10, 20, 30]})
+        assert [f["azimuth"] for f in frames] == [10, 20, 30]
+
+    def test_carries_base_params(self):
+        frames = expand_frames({"file_path": "/x", "field_name": "U", "colormap": "viridis", "frames": 2})
+        assert all(f["file_path"] == "/x" and f["field_name"] == "U" for f in frames)
+
+
+class TestRenderFrames:
+    async def test_yields_one_per_frame(self):
+        req = {"file_path": "/x", "frames": 3}
+        out = [frame async for frame in render_frames(req, _fake_render)]
+        assert len(out) == 3
+        assert all(f.startswith(b"\x89PNG") for f in out)
+
+
+class TestHandleConnection:
+    async def test_streams_frames_then_done(self):
+        ws = _FakeWS(['{"file_path": "/x", "frames": 2}'])
+        await handle_connection(ws, _fake_render)
+        binary = [m for m in ws.sent if isinstance(m, (bytes, bytearray))]
+        texts = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+        assert len(binary) == 2
+        assert texts[-1] == {"done": True, "frames": 2}
+
+    async def test_bad_request_sends_error(self):
+        ws = _FakeWS(["not json{"])
+        await handle_connection(ws, _fake_render)
+        texts = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+        assert "error" in texts[0]
+        # no frames streamed for a bad request
+        assert not [m for m in ws.sent if isinstance(m, (bytes, bytearray))]
+
+    async def test_multiple_requests(self):
+        ws = _FakeWS(['{"file_path": "/a", "frames": 1}', '{"file_path": "/b", "frames": 1}'])
+        await handle_connection(ws, _fake_render)
+        dones = [json.loads(m) for m in ws.sent if isinstance(m, str)]
+        assert len(dones) == 2 and all(d["done"] for d in dones)

--- a/tests/test_remote_vtk.py
+++ b/tests/test_remote_vtk.py
@@ -51,13 +51,14 @@ class TestRealSocketRoundtrip:
         server = asyncio.create_task(serve(host="127.0.0.1", port=port))
         try:
             # wait for the server to accept connections
+            conn = None
             for _ in range(50):
                 try:
                     conn = await websockets.connect(f"ws://127.0.0.1:{port}")
                     break
                 except OSError:
                     await asyncio.sleep(0.1)
-            else:
+            if conn is None:
                 pytest.fail("remote render server did not start")
 
             async with conn:
@@ -78,4 +79,4 @@ class TestRealSocketRoundtrip:
             try:
                 await server
             except asyncio.CancelledError:
-                pass
+                pass  # expected — we cancelled the server task

--- a/tests/test_remote_vtk.py
+++ b/tests/test_remote_vtk.py
@@ -8,10 +8,10 @@ GPU runner.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 
 import numpy as np
-import pytest
 import vtk
 from vtk.util.numpy_support import numpy_to_vtk
 
@@ -59,7 +59,7 @@ class TestRealSocketRoundtrip:
                 except OSError:
                     await asyncio.sleep(0.1)
             if conn is None:
-                pytest.fail("remote render server did not start")
+                raise RuntimeError("remote render server did not start in time")
 
             async with conn:
                 await conn.send(json.dumps({"file_path": path, "field_name": "RTData", "frames": 2}))
@@ -76,7 +76,5 @@ class TestRealSocketRoundtrip:
             assert all(f[:4] == b"\x89PNG" for f in frames)
         finally:
             server.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await server
-            except asyncio.CancelledError:
-                pass  # expected — we cancelled the server task

--- a/tests/test_remote_vtk.py
+++ b/tests/test_remote_vtk.py
@@ -1,0 +1,81 @@
+"""GPU/socket E2E for viznoir.remote — real WebSocket roundtrip with real renders.
+
+Renders an orbit of a VTK wavelet over an actual WebSocket connection. Needs EGL,
+so it is skipped on GitHub-hosted CI (``*_vtk.py``) and runs on the self-hosted
+GPU runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import numpy as np
+import pytest
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk
+
+from viznoir.remote import _default_render_fn, serve
+
+
+def _write_vti(path: str) -> None:
+    n = 6
+    img = vtk.vtkImageData()
+    img.SetDimensions(n, n, n)
+    rt = np.linspace(0.0, 200.0, n * n * n).astype(np.float64)
+    arr = numpy_to_vtk(rt, deep=True)
+    arr.SetName("RTData")
+    img.GetPointData().AddArray(arr)
+    w = vtk.vtkXMLImageDataWriter()
+    w.SetFileName(path)
+    w.SetInputData(img)
+    w.Write()
+
+
+class TestDefaultRenderFn:
+    def test_renders_orbit_frame_to_png(self, tmp_path):
+        path = str(tmp_path / "w.vti")
+        _write_vti(path)
+        png = _default_render_fn({"file_path": path, "field_name": "RTData", "azimuth": 45.0})
+        assert png[:4] == b"\x89PNG"
+        assert len(png) > 1000
+
+
+class TestRealSocketRoundtrip:
+    async def test_stream_orbit_over_websocket(self, tmp_path):
+        import websockets
+
+        path = str(tmp_path / "w.vti")
+        _write_vti(path)
+        port = 14237
+        server = asyncio.create_task(serve(host="127.0.0.1", port=port))
+        try:
+            # wait for the server to accept connections
+            for _ in range(50):
+                try:
+                    conn = await websockets.connect(f"ws://127.0.0.1:{port}")
+                    break
+                except OSError:
+                    await asyncio.sleep(0.1)
+            else:
+                pytest.fail("remote render server did not start")
+
+            async with conn:
+                await conn.send(json.dumps({"file_path": path, "field_name": "RTData", "frames": 2}))
+                frames = []
+                while True:
+                    msg = await asyncio.wait_for(conn.recv(), timeout=30)
+                    if isinstance(msg, (bytes, bytearray)):
+                        frames.append(msg)
+                    else:
+                        done = json.loads(msg)
+                        break
+            assert done == {"done": True, "frames": 2}
+            assert len(frames) == 2
+            assert all(f[:4] == b"\x89PNG" for f in frames)
+        finally:
+            server.cancel()
+            try:
+                await server
+            except asyncio.CancelledError:
+                pass


### PR DESCRIPTION
## Description
Remote render (#67) — `viznoir/remote.py` streams rendered frames over a **WebSocket** from the GPU host.

- client sends JSON (`file_path`, `field_name`, `colormap`, `frames`/`azimuths`)
- server renders an **orbit** of camera azimuths through the renderer singleton, streams each frame as a binary PNG, ends with `{"done": true, "frames": n}`
- malformed request → `{"error": ...}`, connection stays open
- renders run on the event-loop thread (VTK is thread-affine; the shared GPU singleton serializes renders anyway — an injected `render_fn` keeps the transport GPU/socket-free testable)
- run: `python -m viznoir.remote --host 0.0.0.0 --port 14100`

## Test Plan
- `tests/test_remote.py` — **11 unit tests** (parse/expand/stream/handler) with a fake websocket + fake render_fn
- `tests/test_remote_vtk.py` — **2 GPU tests**: `_default_render_fn` real PNG + full real-WebSocket orbit roundtrip (self-hosted 3.12)
- `remote.py` at **100%** coverage; `ruff` + `mypy` clean
- **E2E (real socket, real GPU renders)** — `e2e/scenarios/remote_render_e2e.py`: 3 orbit frames streamed over a real WebSocket with sizes 131/240/189 KB (distinct camera angles → genuine renders, not echoes). 4/4 checks pass. Report: `e2e/reports/2026-06-16-67-remote-render.md`

Closes #67

🤖 ultraloop iteration 10
